### PR TITLE
Add installer script for Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+SOURCE_PATH=$(dirname $(readlink -f $0))
+DESTINATION_PREFIX="/usr/local"
+SHARE_PATH="${DESTINATION_PREFIX}/share"
+APPLICATIONS_PATH="${SHARE_PATH}/applications"
+BIN_PATH="${DESTINATION_PREFIX}/bin"
+DESTINATION_PATH="${SHARE_PATH}/TinyPedal"
+
+if [ ! -f "pyRfactor2SharedMemory/__init__.py" ];
+then
+    echo "Missing files. Please, use a Linux source release file or 'git clone --recurse-submodules'."
+    exit 1
+fi
+
+if [ ! -w "${SHARE_PATH}" -o ! -w "${BIN_PATH}" -o ! -w "${APPLICATIONS_PATH}" ];
+then
+    echo "Insufficient privileges to install in the prefix directory: ${DESTINATION_PREFIX}"
+    exit 1
+fi
+
+if [ -d "${DESTINATION_PATH}" ];
+then
+    if [ -w "${DESTINATION_PATH}" ];
+    then
+        rm -r "${DESTINATION_PATH}"
+    else
+        echo "Insufficient privileges to update existing install."
+        exit 1
+    fi
+fi
+
+echo "Writing ${DESTINATION_PATH}"
+cp -r "${SOURCE_PATH}" "${DESTINATION_PATH}"
+
+echo "Writing ${APPLICATIONS_PATH}/svictor.TinyPedal.desktop"
+cp "${SOURCE_PATH}/svictor-TinyPedal.desktop" "${APPLICATIONS_PATH}"
+
+echo "Writing ${BIN_PATH}/TinyPedal"
+ln -fs "${DESTINATION_PATH}/run.py" "${BIN_PATH}/TinyPedal"
+
+echo "Installation finished."

--- a/run.py
+++ b/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 #  TinyPedal is an open-source overlay application for racing simulation.
 #  Copyright (C) 2022  Xiang
 #

--- a/svictor-TinyPedal.desktop
+++ b/svictor-TinyPedal.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Exec=/usr/local/share/TinyPedal/run.py
+GenericName=Overlay for rFactor2
+Icon=/usr/local/share/TinyPedal/icon.png
+Name=TinyPedal
+Path=/usr/local/share/TinyPedal
+StartupNotify=true
+Terminal=false
+Type=Application


### PR DESCRIPTION
I've added a shebang line to `run.py` that allows the script to be run directly on Linux. Windows uses its own file association mechanisms and will ignore the shebang line.

The script `install.sh` does the installation. It will install a desktop file so that it can be run from the desktop, and a link in `/usr/local/bin` so that it can also be run from the command line.

The install script expects the `pyRfactor2SharedMemory` directory to be populated. It checks for the `__init__.py` file.