### PR TITLE
Remove always on top on main window (Linux)

### DIFF
--- a/tinypedal/preset.py
+++ b/tinypedal/preset.py
@@ -40,7 +40,8 @@ class LoadPreset(tk.Toplevel):
     def __init__(self, master):
         tk.Toplevel.__init__(self)
         self.master = master
-        self.attributes("-topmost", 1)
+        if PLATFORM == "Windows":
+            self.attributes("-topmost", 1)
 
         # Base setting
         fg_color = "#222"


### PR DESCRIPTION
Minimizing the main window on start doesn't work on Gnome. Probably because Gnome doesn't have a taskbar and it would seem the app never started.

This coupled with the main window always on top is annoying. I think it isn't needed anyway since the window is currently drawn over the game window when focused.