### PR TITLE
Change cwd at start

### DIFF
--- a/run.py
+++ b/run.py
@@ -23,6 +23,7 @@ Run program
 """
 
 import os
+import sys
 from tkinter import messagebox
 import psutil
 from tinypedal.about import About
@@ -60,4 +61,5 @@ def load_tinypedal():
 
 
 if __name__ == "__main__":
+    os.chdir(os.path.dirname(os.path.abspath(sys.argv[0])))
     load_tinypedal()


### PR DESCRIPTION
TinyPedal fails to run if the current working directory isn't the app directory. When installed on Linux, the console command fails for this reason. With this change TinyPedal can be run from any place.