### PR TITLE
Fix tray settings sync

### DIFF
--- a/tinypedal/tray.py
+++ b/tinypedal/tray.py
@@ -99,7 +99,7 @@ class TrayIcon(QSystemTrayIcon):
         menu.addAction(app_quit)
 
         self.setContextMenu(menu)
-        self.activated.connect(self.refresh_menu)
+        menu.aboutToShow.connect(self.refresh_menu)
 
     def show_config(self):
         """Show config window"""


### PR DESCRIPTION
When changing the "Lock overlay" and "Auto hide" settings from the main window menu, the tray menu isn't updated.

Example: Set "Auto hide" from the main window menu, then open the tray and the "Auto hide" setting is disabled only there. Same with "Lock overlay".

Tested on Gnome 43.6 on Debian 12.

It works with this change. The "activated" signal isn't working for some reason.