### PR TITLE
Fix running on Wayland

### DIFF
--- a/TinyPedal.sh
+++ b/TinyPedal.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+env XDG_SESSION_TYPE=x11 ./run.py "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SOURCE_PATH=$(dirname $(readlink -f $0))
 DESTINATION_PREFIX="/usr/local"
@@ -6,6 +6,27 @@ SHARE_PATH="${DESTINATION_PREFIX}/share"
 APPLICATIONS_PATH="${SHARE_PATH}/applications"
 BIN_PATH="${DESTINATION_PREFIX}/bin"
 DESTINATION_PATH="${SHARE_PATH}/TinyPedal"
+
+replace() {
+    PATTERN="$1"
+    STRING="$2"
+    while read LINE; do
+        echo "${LINE/${PATTERN}/${STRING}}"
+    done
+}
+
+if [ -n "$1" ];
+then
+    DESTINATION_PREFIX="$1"
+    while true; do
+        read -p "Are you sure you want to install this program to '${DESTINATION_PREFIX}' prefix? " yn
+        case $yn in
+            [Yy]* ) break;;
+            [Nn]* ) exit;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
+fi
 
 if [ ! -f "pyRfactor2SharedMemory/__init__.py" ];
 then
@@ -33,10 +54,11 @@ fi
 echo "Writing ${DESTINATION_PATH}"
 cp -r "${SOURCE_PATH}" "${DESTINATION_PATH}"
 
-echo "Writing ${APPLICATIONS_PATH}/svictor.TinyPedal.desktop"
-cp "${SOURCE_PATH}/svictor-TinyPedal.desktop" "${APPLICATIONS_PATH}"
+echo "Writing ${APPLICATIONS_PATH}/svictor-TinyPedal.desktop"
+replace "{.}" "${DESTINATION_PATH}" <"${SOURCE_PATH}/svictor-TinyPedal.desktop" >"${APPLICATIONS_PATH}/svictor-TinyPedal.desktop"
 
 echo "Writing ${BIN_PATH}/TinyPedal"
-ln -fs "${DESTINATION_PATH}/run.py" "${BIN_PATH}/TinyPedal"
+replace "./" "${DESTINATION_PATH}/" <"${SOURCE_PATH}/TinyPedal.sh" >"${BIN_PATH}/TinyPedal"
+chmod a+x "${BIN_PATH}/TinyPedal"
 
 echo "Installation finished."

--- a/svictor-TinyPedal.desktop
+++ b/svictor-TinyPedal.desktop
@@ -1,9 +1,9 @@
 [Desktop Entry]
-Exec=/usr/local/share/TinyPedal/run.py
+Exec=env XDG_SESSION_TYPE=x11 {.}/run.py
 GenericName=Overlay for rFactor2
-Icon=/usr/local/share/TinyPedal/images/icon.png
+Icon={.}/images/icon.png
 Name=TinyPedal
-Path=/usr/local/share/TinyPedal
+Path={.}
 StartupNotify=true
 Terminal=false
 Type=Application


### PR DESCRIPTION
This is a fix for issue #30 implementing the workaround to force a x11 session type. Tested on Gnome with X11 and Wayland.

I've also implemented some path replacement for the new comand line script and the existing desktop file so TinyPedal can be installed anywhere passing an argument to the install script, making it more flexible to install.

I'll ask for more testing.