### PR TITLE
Add resizable overlay grid for widget positioning

### DIFF
--- a/tinypedal/base.py
+++ b/tinypedal/base.py
@@ -65,7 +65,10 @@ class Widget(QWidget):
     def mouseMoveEvent(self, event):
         """Update widget position"""
         if event.buttons() == Qt.LeftButton:
-            self.move(event.globalPos() - self.mouse_pos)
+            pos = (event.globalPos() - self.mouse_pos)
+            if self.cfg.overlay["enable_grid"]:
+                pos = pos / self.cfg.compatibility["grid_size"] * self.cfg.compatibility["grid_size"]
+            self.move(pos)
 
     def mousePressEvent(self, event):
         """Set offset position & press state"""
@@ -85,6 +88,7 @@ class Widget(QWidget):
         """Set initial widget state"""
         # Window flags
         self.setWindowOpacity(self.wcfg["opacity"])
+        self.setAttribute(Qt.WA_X11NetWmWindowTypeDock, True)
         if self.cfg.compatibility["enable_translucent_background"]:
             self.setAttribute(Qt.WA_TranslucentBackground, True)
         self.setAttribute(Qt.WA_DeleteOnClose, True)

--- a/tinypedal/base.py
+++ b/tinypedal/base.py
@@ -66,8 +66,8 @@ class Widget(QWidget):
         """Update widget position"""
         if event.buttons() == Qt.LeftButton:
             pos = (event.globalPos() - self.mouse_pos)
-            if self.cfg.overlay["enable_grid"]:
-                pos = pos / self.cfg.compatibility["grid_size"] * self.cfg.compatibility["grid_size"]
+            if self.cfg.overlay["enable_grid_move"]:
+                pos = pos / self.cfg.compatibility["grid_move_size"] * self.cfg.compatibility["grid_move_size"]
             self.move(pos)
 
     def mousePressEvent(self, event):

--- a/tinypedal/main.py
+++ b/tinypedal/main.py
@@ -111,9 +111,9 @@ class AppWindow(QMainWindow):
         self.overlay_hide.triggered.connect(self.is_hidden)
         menu_overlay.addAction(self.overlay_hide)
 
-        self.overlay_grid = QAction("Enable Grid", self)
+        self.overlay_grid = QAction("Grid move", self)
         self.overlay_grid.setCheckable(True)
-        self.overlay_grid.setChecked(cfg.overlay["enable_grid"])
+        self.overlay_grid.setChecked(cfg.overlay["enable_grid_move"])
         self.overlay_grid.triggered.connect(self.has_grid)
         menu_overlay.addAction(self.overlay_grid)
 
@@ -192,6 +192,7 @@ class AppWindow(QMainWindow):
         """Refresh overlay menu"""
         self.overlay_lock.setChecked(cfg.overlay["fixed_position"])
         self.overlay_hide.setChecked(cfg.overlay["auto_hide"])
+        self.overlay_grid.setChecked(cfg.overlay["enable_grid_move"])
 
     def start_app(self):
         """Start modules & widgets"""

--- a/tinypedal/main.py
+++ b/tinypedal/main.py
@@ -111,6 +111,12 @@ class AppWindow(QMainWindow):
         self.overlay_hide.triggered.connect(self.is_hidden)
         menu_overlay.addAction(self.overlay_hide)
 
+        self.overlay_grid = QAction("Enable Grid", self)
+        self.overlay_grid.setCheckable(True)
+        self.overlay_grid.setChecked(cfg.overlay["enable_grid"])
+        self.overlay_grid.triggered.connect(self.has_grid)
+        menu_overlay.addAction(self.overlay_grid)
+
         menu_overlay.aboutToShow.connect(self.refresh_overlay_menu)
 
         reload_preset = QAction("Reload", self)
@@ -271,6 +277,11 @@ class AppWindow(QMainWindow):
     def is_hidden():
         """Check hide state"""
         octrl.overlay_hide.toggle()
+
+    @staticmethod
+    def has_grid():
+        """Check hide state"""
+        octrl.overlay_grid.toggle()
 
     @staticmethod
     def is_show_at_startup():

--- a/tinypedal/overlay_control.py
+++ b/tinypedal/overlay_control.py
@@ -54,6 +54,22 @@ class OverlayLock(QObject):
         self.cfg.save()
 
 
+class OverlayGrid(QObject):
+    """Overlay grid state"""
+
+    def __init__(self, config):
+        super().__init__()
+        self.cfg = config
+
+    def toggle(self):
+        """Toggle lock state"""
+        if not self.cfg.overlay["enable_grid"]:
+            self.cfg.overlay["enable_grid"] = True
+        else:
+            self.cfg.overlay["enable_grid"] = False
+        self.cfg.save()
+
+
 class OverlayAutoHide(QObject):
     """Auto hide overlay"""
     hidden = Signal(bool)
@@ -107,6 +123,7 @@ class OverlayControl:
         self.overlay_lock = OverlayLock(cfg)
         self.overlay_hide = OverlayAutoHide(cfg)
         self.overlay_hide.start()
+        self.overlay_grid = OverlayGrid(cfg)
 
     def disable(self):
         """Disable overlay control"""

--- a/tinypedal/overlay_control.py
+++ b/tinypedal/overlay_control.py
@@ -63,10 +63,10 @@ class OverlayGrid(QObject):
 
     def toggle(self):
         """Toggle lock state"""
-        if not self.cfg.overlay["enable_grid"]:
-            self.cfg.overlay["enable_grid"] = True
+        if not self.cfg.overlay["enable_grid_move"]:
+            self.cfg.overlay["enable_grid_move"] = True
         else:
-            self.cfg.overlay["enable_grid"] = False
+            self.cfg.overlay["enable_grid_move"] = False
         self.cfg.save()
 
 

--- a/tinypedal/template/setting_application.py
+++ b/tinypedal/template/setting_application.py
@@ -33,10 +33,12 @@ APPLICATION_DEFAULT = {
         "enable_bypass_window_manager": False,
         "enable_translucent_background": True,
         "global_bkg_color": "#000000",
+        "grid_size": 8,
     },
     "overlay": {
         "fixed_position": False,
         "auto_hide": True,
+        "enable_grid": False,
     },
     "shared_memory_api": {
         "api_name": "rFactor 2",

--- a/tinypedal/template/setting_application.py
+++ b/tinypedal/template/setting_application.py
@@ -33,12 +33,12 @@ APPLICATION_DEFAULT = {
         "enable_bypass_window_manager": False,
         "enable_translucent_background": True,
         "global_bkg_color": "#000000",
-        "grid_size": 8,
+        "grid_move_size": 8,
     },
     "overlay": {
         "fixed_position": False,
         "auto_hide": True,
-        "enable_grid": False,
+        "enable_grid_move": False,
     },
     "shared_memory_api": {
         "api_name": "rFactor 2",

--- a/tinypedal/tray.py
+++ b/tinypedal/tray.py
@@ -67,6 +67,13 @@ class TrayIcon(QSystemTrayIcon):
         self.overlay_hide.triggered.connect(self.master.is_hidden)
         menu.addAction(self.overlay_hide)
 
+        # Grid
+        self.overlay_grid = QAction("Enable Grid", self)
+        self.overlay_grid.setCheckable(True)
+        self.overlay_grid.setChecked(self.cfg.overlay["enable_grid"])
+        self.overlay_grid.triggered.connect(self.master.has_grid)
+        menu.addAction(self.overlay_grid)
+
         # Reload preset
         reload_preset = QAction("Reload", self)
         reload_preset.triggered.connect(self.master.reload_preset)
@@ -113,6 +120,7 @@ class TrayIcon(QSystemTrayIcon):
         )
         self.overlay_lock.setChecked(self.cfg.overlay["fixed_position"])
         self.overlay_hide.setChecked(self.cfg.overlay["auto_hide"])
+        self.overlay_grid.setChecked(self.cfg.overlay["enable_grid"])
 
     @staticmethod
     def format_preset_name(filename):

--- a/tinypedal/tray.py
+++ b/tinypedal/tray.py
@@ -68,9 +68,9 @@ class TrayIcon(QSystemTrayIcon):
         menu.addAction(self.overlay_hide)
 
         # Grid
-        self.overlay_grid = QAction("Enable Grid", self)
+        self.overlay_grid = QAction("Grid move", self)
         self.overlay_grid.setCheckable(True)
-        self.overlay_grid.setChecked(self.cfg.overlay["enable_grid"])
+        self.overlay_grid.setChecked(self.cfg.overlay["enable_grid_move"])
         self.overlay_grid.triggered.connect(self.master.has_grid)
         menu.addAction(self.overlay_grid)
 
@@ -120,7 +120,7 @@ class TrayIcon(QSystemTrayIcon):
         )
         self.overlay_lock.setChecked(self.cfg.overlay["fixed_position"])
         self.overlay_hide.setChecked(self.cfg.overlay["auto_hide"])
-        self.overlay_grid.setChecked(self.cfg.overlay["enable_grid"])
+        self.overlay_grid.setChecked(self.cfg.overlay["enable_grid_move"])
 
     @staticmethod
     def format_preset_name(filename):


### PR DESCRIPTION
I think this would help correctly align widgets with less effort. The grid can be enabled in the Overlay menu or in the tray the same way as the lock and autohide features. The grid is invisible.  The grid size can be set in the compatibility config.

I'm not happy putting the grid size in the compatibility window but I didn't feel like creating a new window only for it. Suggestions welcomed.

I added an attribute to the widgets to set them as type Dock. I hope this doesn't cause any trouble. I think it's compatible with how we expect the widgets to behave. I had to add it so that widgets could go over the top bar in Gnome and also extend past the screen. Without this attribute widgets were confined inside the workspace.