### PR TITLE
Remove window type dock for widgets

### DIFF
--- a/tinypedal/base.py
+++ b/tinypedal/base.py
@@ -89,7 +89,6 @@ class Widget(QWidget):
         """Set initial widget state"""
         # Window flags
         self.setWindowOpacity(self.wcfg["opacity"])
-        self.setAttribute(Qt.WA_X11NetWmWindowTypeDock, True)
         if self.cfg.compatibility["enable_translucent_background"]:
             self.setAttribute(Qt.WA_TranslucentBackground, True)
         self.setAttribute(Qt.WA_DeleteOnClose, True)


### PR DESCRIPTION
It makes widgets visible on Gnome with bypass window manager enabled or disabled. Disabled allows OBS to capture widget windows, enabled allow the widgets to move freely on Gnome.

Should we change the default for bypass window manager?

Continuation from #36.