### PR TITLE
Roughly implemented game detection

### DIFF
--- a/tinypedal/main.py
+++ b/tinypedal/main.py
@@ -25,6 +25,7 @@ import sys
 import signal
 import logging
 import psutil
+import threading
 
 from PySide2.QtGui import QFont
 from PySide2.QtWidgets import QApplication, QMessageBox
@@ -33,7 +34,7 @@ from . import log_stream
 from .cli_argument import get_cli_argument
 from .const import APP_NAME, PLATFORM, VERSION, PYTHON_VERSION, QT_VERSION, PATH_LOG
 from .log_handler import set_logging_level
-from .monitoring import monitor_thread
+from .monitoring import monitor_process
 
 EXE_NAME = "tinypedal.exe"
 PID_FILE = "pid.log"
@@ -133,11 +134,19 @@ def start_app():
     # Load core modules
     from . import loader
     loader.load()
-    # start monitoring game launch
-    monitor_thread.start()
+
     # Start main window
     from tinypedal.ui.app import AppWindow
     config_window = AppWindow()
     signal.signal(signal.SIGINT, config_window.int_signal_handler)
+
+    # start monitoring game launch
+    # Create a thread to run the monitoring function in the background
+    monitor_thread = threading.Thread(target=monitor_process, 
+                                      args=(["rFactor2.exe", "Le Mans Ultimate.exe"], 
+                                            config_window))
+    monitor_thread.daemon = True
+    monitor_thread.start()
+    
     # Start mainloop
     sys.exit(root.exec_())

--- a/tinypedal/main.py
+++ b/tinypedal/main.py
@@ -34,7 +34,6 @@ from . import log_stream
 from .cli_argument import get_cli_argument
 from .const import APP_NAME, PLATFORM, VERSION, PYTHON_VERSION, QT_VERSION, PATH_LOG
 from .log_handler import set_logging_level
-from .monitoring import monitor_process
 
 EXE_NAME = "tinypedal.exe"
 PID_FILE = "pid.log"
@@ -142,10 +141,10 @@ def start_app():
 
     # start monitoring game launch
     # Create a thread to run the monitoring function in the background
+    from .monitoring import monitor_process
     monitor_thread = threading.Thread(target=monitor_process, 
-                                      args=(["rFactor2.exe", "Le Mans Ultimate.exe"], 
-                                            config_window))
-    monitor_thread.daemon = True
+                                      args=(config_window,),
+                                      daemon=True)
     monitor_thread.start()
     
     # Start mainloop

--- a/tinypedal/main.py
+++ b/tinypedal/main.py
@@ -33,6 +33,7 @@ from . import log_stream
 from .cli_argument import get_cli_argument
 from .const import APP_NAME, PLATFORM, VERSION, PYTHON_VERSION, QT_VERSION, PATH_LOG
 from .log_handler import set_logging_level
+from .monitoring import monitor_thread
 
 EXE_NAME = "tinypedal.exe"
 PID_FILE = "pid.log"
@@ -132,6 +133,8 @@ def start_app():
     # Load core modules
     from . import loader
     loader.load()
+    # start monitoring game launch
+    monitor_thread.start()
     # Start main window
     from tinypedal.ui.app import AppWindow
     config_window = AppWindow()

--- a/tinypedal/monitoring.py
+++ b/tinypedal/monitoring.py
@@ -2,60 +2,62 @@ from __future__ import annotations
 import logging
 import time
 import psutil
-from dataclasses import dataclass
 
-from .const import PLATFORM, PATH_SETTINGS, PATH_BRANDLOGO
 from .setting_validator import PresetValidator
 
-from .template.setting_application import APPLICATION_DEFAULT
-from .template.setting_module import MODULE_DEFAULT
-from .template.setting_widget import WIDGET_DEFAULT
-from .template.setting_classes import CLASSES_DEFAULT
-from .template.setting_heatmap import HEATMAP_DEFAULT
-
+from .api_control import api
 from .setting import cfg
 
 logger = logging.getLogger(__name__)
 preset_validator = PresetValidator()
 
-def monitor_process(exe_names, config_window):
-    """
-    Monitors processes in real-time and notifies when the specified executable is launched.
+# def monitor_process(exe_names, config_window):
 
-    Args:
-        exe_name: The name of the executable to monitor.
-    """
-
-    # set of detected game exe
-    detected = set()
+#     # set of detected game exe
+#     detected = set()
     
+#     while True:
+#         procs = [proc.name() for proc in psutil.process_iter()]
+#         try:
+#             for exe_name in exe_names:
+#                 if exe_name in procs:
+#                     # set preset and add exe name to detected if it is running
+#                     if exe_name not in detected:
+#                         set_preset(exe_name)
+#                         config_window.preset_tab.refresh_list()  # refresh UI
+#                         detected.add(exe_name)
+#                 else:
+#                     # delete exe name from detected if it is not running
+#                     if exe_name in detected:
+#                         detected.discard(exe_name)
+#         except (psutil.NoSuchProcess, psutil.AccessDenied):
+#             pass
+
+#         time.sleep(1)
+
+#     time.sleep(1)  # Adjust the sleep interval as needed
+
+def monitor_process(config_window):
     while True:
-        procs = [proc.name() for proc in psutil.process_iter()]
-        try:
-            for exe_name in exe_names:
-                if exe_name in procs:
-                    # set preset and add exe name to detected if it is running
-                    if exe_name not in detected:
-                        set_preset(exe_name)
-                        config_window.preset_tab.refresh_list()  # refresh UI
-                        detected.add(exe_name)
-                else:
-                    # delete exe name from detected if it is not running
-                    if exe_name in detected:
-                        detected.discard(exe_name)
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
+        sim_name = api.read.check.sim_name()  # returns "" if no game running
+
+        # Available sim_name: "RF2", "LMU"
+        if sim_name:
+            # Set preset and assign sim name to last detected if game running
+            if sim_name != cfg.last_detected_sim:
+                logger.info(f"SETTING: game detected: {cfg.last_detected_sim}")
+                set_preset(sim_name)
+                cfg.last_detected_sim = sim_name
+                config_window.preset_tab.refresh_list()  # refresh UI
+        else:
+            # Clear detected name if no game found
+            if cfg.last_detected_sim:
+                cfg.last_detected_sim = None
 
         time.sleep(1)
 
-    time.sleep(1)  # Adjust the sleep interval as needed
-
-def set_preset(exe_name):
+def set_preset(sim_name):
     # set preset according to detected exe
-    preset_name = preset_dict[exe_name]
+    preset_name = cfg.sim_specific_preset[sim_name]
     cfg.filename.setting = f"{preset_name}.json"
     cfg.load()
-
-
-# {exe_name: preset_name} dictionary
-preset_dict = {"Le Mans Ultimate.exe": "Le Mans Ultimate", "rFactor2.exe": "rFactor 2"}

--- a/tinypedal/monitoring.py
+++ b/tinypedal/monitoring.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+import logging
+import time
+import threading
+import psutil
+from dataclasses import dataclass
+
+from .const import PLATFORM, PATH_SETTINGS, PATH_BRANDLOGO
+from .setting_validator import PresetValidator
+
+from .template.setting_application import APPLICATION_DEFAULT
+from .template.setting_module import MODULE_DEFAULT
+from .template.setting_widget import WIDGET_DEFAULT
+from .template.setting_classes import CLASSES_DEFAULT
+from .template.setting_heatmap import HEATMAP_DEFAULT
+
+from .setting import cfg
+
+logger = logging.getLogger(__name__)
+preset_validator = PresetValidator()
+
+def monitor_process(exe_names):
+    """
+    Monitors processes in real-time and notifies when the specified executable is launched.
+
+    Args:
+        exe_name: The name of the executable to monitor.
+    """
+
+    while True:
+        procs = [proc.name() for proc in psutil.process_iter()]
+        try:
+            for exe_name in exe_names:
+                if exe_name in procs:
+                    # set preset and add exe name to detected if it is running
+                    if exe_name not in detected:
+                        set_preset(exe_name)
+                        detected.add(exe_name)
+                else:
+                    # delete exe name from detected if it is not running
+                    if exe_name in detected:
+                        detected.discard(exe_name)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+        time.sleep(1)
+
+    time.sleep(1)  # Adjust the sleep interval as needed
+
+def set_preset(exe_name):
+    # set preset according to detected exe
+    preset_name = preset_dict[exe_name]
+    cfg.filename.setting = f"{preset_name}.json"
+    cfg.load()
+
+
+# {exe_name: preset_name} dictionary
+preset_dict = {"Le Mans Ultimate.exe": "Le Mans Ultimate", "rFactor2.exe": "rFactor 2"}
+
+# set of detected game exe
+detected = set()
+
+# Create a thread to run the monitoring function in the background
+monitor_thread = threading.Thread(target=monitor_process, args=(["rFactor2.exe", "Le Mans Ultimate.exe"],))
+monitor_thread.daemon = True

--- a/tinypedal/monitoring.py
+++ b/tinypedal/monitoring.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import logging
 import time
-import threading
 import psutil
 from dataclasses import dataclass
 
@@ -19,7 +18,7 @@ from .setting import cfg
 logger = logging.getLogger(__name__)
 preset_validator = PresetValidator()
 
-def monitor_process(exe_names):
+def monitor_process(exe_names, config_window):
     """
     Monitors processes in real-time and notifies when the specified executable is launched.
 
@@ -27,6 +26,9 @@ def monitor_process(exe_names):
         exe_name: The name of the executable to monitor.
     """
 
+    # set of detected game exe
+    detected = set()
+    
     while True:
         procs = [proc.name() for proc in psutil.process_iter()]
         try:
@@ -35,6 +37,7 @@ def monitor_process(exe_names):
                     # set preset and add exe name to detected if it is running
                     if exe_name not in detected:
                         set_preset(exe_name)
+                        config_window.preset_tab.refresh_list()  # refresh UI
                         detected.add(exe_name)
                 else:
                     # delete exe name from detected if it is not running
@@ -56,10 +59,3 @@ def set_preset(exe_name):
 
 # {exe_name: preset_name} dictionary
 preset_dict = {"Le Mans Ultimate.exe": "Le Mans Ultimate", "rFactor2.exe": "rFactor 2"}
-
-# set of detected game exe
-detected = set()
-
-# Create a thread to run the monitoring function in the background
-monitor_thread = threading.Thread(target=monitor_process, args=(["rFactor2.exe", "Le Mans Ultimate.exe"],))
-monitor_thread.daemon = True

--- a/tinypedal/overlay_control.py
+++ b/tinypedal/overlay_control.py
@@ -81,6 +81,7 @@ class OverlayState(QObject):
         super().__init__()
         self.stopped = True
         self.active = False
+        # self.autoload = True
         self.event = threading.Event()
         self._auto_hide_timer = StateTimer(0.4)
 
@@ -92,9 +93,17 @@ class OverlayState(QObject):
             threading.Thread(target=self.__updating, daemon=True).start()
             logger.info("ACTIVE: overlay control")
 
+        # if self.autoload:
+        #    threading.Thread(target=self.__autoload, daemon=True).start()
+        #    logger.info("ACTIVE: autoload preset")
+
     def stop(self):
         """Stop thread"""
         self.event.set()
+
+    def __autoload(self):
+        """auto-load sim specific preset"""
+        # monitor_process()
 
     def __updating(self):
         """Update global state"""

--- a/tinypedal/setting.py
+++ b/tinypedal/setting.py
@@ -91,6 +91,9 @@ class Setting:
         self.user = Preset()
         self.is_saving = False
         self._save_delay = 0
+        self.last_detected_sim = None
+        self.sim_specific_preset = {"LMU": "Le Mans Ultimate", 
+                                    "RF2": "rFactor 2"}
 
     def load(self):
         """Load all setting files"""


### PR DESCRIPTION
I added a daemon thread that runs in the background and checks if "rFactor 2.exe" or "Le Mans Ultimate.exe" is launched. 

If either of the apps is launched, a corresponding preset is automatically loaded. For now, the preset name for rF2 should be exactly "**rFactor 2**" and for LMU exactly "**Le Mans Ultimate**". This approach is not ideal, but I wanted to provide a simple running example of #58.

The daemon thread is created in `monitoring.py` and is started in `start_app()` in `main.py`. `psutil` package was used to monitor running processes.