### PR TITLE
Added VR compatibility mode in order for widgets to be used with OpenKneeboard

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -349,7 +349,8 @@ To share user path across multiple copies of TinyPedal, user must set path to pl
 
     fixed_position
 Check whether widget is locked at startup. This setting can be toggled from tray icon menu. Valid value: `true`, same as `1`. `false`, same as `0`.
-
+    vr_comp
+Enables visiblity of widgets as tabs in order to be used in VR via apps such as OpenKneeboard. Valid value: `true`, same as `1`. `false`, same as `0`.
     auto_hide
 Check whether auto hide is enabled. This setting can be toggled from tray icon menu. Valid value: `true`, same as `1`. `false`, same as `0`.
 

--- a/tinypedal/overlay_control.py
+++ b/tinypedal/overlay_control.py
@@ -86,6 +86,7 @@ class OverlayState(QObject):
     """
     hidden = Signal(bool)
     locked = Signal(bool)
+    vr_comp = Signal(bool)
     reload = Signal(bool)
 
     def __init__(self):
@@ -176,6 +177,11 @@ class OverlayControl:
     def disable(self):
         """Disable overlay control"""
         self.state.stop()
+
+    def toggle_vr(self):
+        """Toggle VR state"""
+        self.__toggle_option("vr_comp")
+        self.state.vr_comp.emit(cfg.overlay["vr_comp"])
 
     def toggle_lock(self):
         """Toggle lock state"""

--- a/tinypedal/regex_pattern.py
+++ b/tinypedal/regex_pattern.py
@@ -28,7 +28,7 @@ CFG_BOOL = (
     "^auto_hide$|"
     "^auto_hide_if_not_available$|"
     "^auto_hide_in_private_qualifying$|"
-    "^vr_comp"
+    "^vr_comp$|"
     "^fixed_position$|"
     "^minimize_to_tray$|"
     "^remember_position$|"

--- a/tinypedal/regex_pattern.py
+++ b/tinypedal/regex_pattern.py
@@ -28,6 +28,7 @@ CFG_BOOL = (
     "^auto_hide$|"
     "^auto_hide_if_not_available$|"
     "^auto_hide_in_private_qualifying$|"
+    "^vr_comp"
     "^fixed_position$|"
     "^minimize_to_tray$|"
     "^remember_position$|"

--- a/tinypedal/template/setting_common.py
+++ b/tinypedal/template/setting_common.py
@@ -26,8 +26,10 @@ from ..regex_pattern import API_NAME_RF2
 COMMON_DEFAULT = {
     "overlay": {
         "fixed_position": False,
+        "vr_comp": False,
         "auto_hide": True,
-        "enable_grid_move": False,
+        "enable_grid_move": False
+
     },
     "shared_memory_api": {
         "api_name": API_NAME_RF2,

--- a/tinypedal/ui/menu.py
+++ b/tinypedal/ui/menu.py
@@ -116,7 +116,7 @@ class OverlayMenu(QMenu):
     def refresh_menu(self):
         """Refresh menu"""
         self.overlay_lock.setChecked(cfg.overlay["fixed_position"])
-        self.overlay_lock.setChecked(cfg.overlay["vr_comp"])
+        self.overlay_vr.setChecked(cfg.overlay["vr_comp"])
         self.overlay_hide.setChecked(cfg.overlay["auto_hide"])
         self.overlay_grid.setChecked(cfg.overlay["enable_grid_move"])
 
@@ -131,7 +131,6 @@ class OverlayMenu(QMenu):
     def is_locked():
         """Check lock state"""
         octrl.toggle_lock()
-
     @staticmethod
     def vr_comp():
         """Check vr state"""

--- a/tinypedal/ui/menu.py
+++ b/tinypedal/ui/menu.py
@@ -63,6 +63,12 @@ class OverlayMenu(QMenu):
         self.overlay_lock.triggered.connect(self.is_locked)
         self.addAction(self.overlay_lock)
 
+        # VR Compatbiility
+        self.overlay_vr = QAction("VR Compatibility", self)
+        self.overlay_vr.setCheckable(True)
+        self.overlay_vr.triggered.connect(self.vr_comp)
+        self.addAction(self.overlay_vr)
+
         # Auto hide
         self.overlay_hide = QAction("Auto Hide", self)
         self.overlay_hide.setCheckable(True)
@@ -110,6 +116,7 @@ class OverlayMenu(QMenu):
     def refresh_menu(self):
         """Refresh menu"""
         self.overlay_lock.setChecked(cfg.overlay["fixed_position"])
+        self.overlay_lock.setChecked(cfg.overlay["vr_comp"])
         self.overlay_hide.setChecked(cfg.overlay["auto_hide"])
         self.overlay_grid.setChecked(cfg.overlay["enable_grid_move"])
 
@@ -126,10 +133,13 @@ class OverlayMenu(QMenu):
         octrl.toggle_lock()
 
     @staticmethod
+    def vr_comp():
+        """Check vr state"""
+        octrl.toggle_vr()
+    @staticmethod
     def is_hidden():
         """Check hide state"""
         octrl.toggle_hide()
-
     @staticmethod
     def has_grid():
         """Check grid move state"""

--- a/tinypedal/widget/_base.py
+++ b/tinypedal/widget/_base.py
@@ -105,9 +105,6 @@ class Overlay(QWidget):
         self.setWindowFlag(Qt.FramelessWindowHint, True)
         if self.cfg.overlay["vr_comp"]:
             self.setWindowFlag(Qt.Tool, False)
-        else:
-            self.setWindowFlag(Qt.Tool, True)  # remove taskbar icon
-            
         self.setWindowFlag(Qt.WindowStaysOnTopHint, True)
         if self.cfg.compatibility["enable_bypass_window_manager"]:
             self.setWindowFlag(Qt.X11BypassWindowManagerHint, True)
@@ -152,7 +149,7 @@ class Overlay(QWidget):
     
     def __toggle_vr_comp(self, vr_comp: bool):
         """Toggle widget VR compatibility"""
-        self.setWindowFlag(Qt.Tool, vr_comp)
+        self.setWindowFlag(Qt.Tool, not vr_comp)
 
     def __connect_signal(self):
         """Connect overlay lock and hide signal"""

--- a/tinypedal/widget/_base.py
+++ b/tinypedal/widget/_base.py
@@ -152,7 +152,7 @@ class Overlay(QWidget):
     
     def __toggle_vr_comp(self, vr_comp: bool):
         """Toggle widget VR compatibility"""
-        self.setWindowFlag(Qt.Tool, not vr_comp)
+        self.setWindowFlag(Qt.Tool, vr_comp)
 
     def __connect_signal(self):
         """Connect overlay lock and hide signal"""

--- a/tinypedal/widget/_base.py
+++ b/tinypedal/widget/_base.py
@@ -103,7 +103,11 @@ class Overlay(QWidget):
     def __set_window_flags(self):
         """Set window flags"""
         self.setWindowFlag(Qt.FramelessWindowHint, True)
-        self.setWindowFlag(Qt.Tool, True)  # remove taskbar icon
+        if self.cfg.overlay["vr_comp"]:
+            self.setWindowFlag(Qt.Tool, False)
+        else:
+            self.setWindowFlag(Qt.Tool, True)  # remove taskbar icon
+            
         self.setWindowFlag(Qt.WindowStaysOnTopHint, True)
         if self.cfg.compatibility["enable_bypass_window_manager"]:
             self.setWindowFlag(Qt.X11BypassWindowManagerHint, True)
@@ -144,17 +148,23 @@ class Overlay(QWidget):
     @Slot(bool)
     def __toggle_lock(self, locked: bool):
         """Toggle widget lock state"""
-        self.setWindowFlag(Qt.WindowTransparentForInput, locked)
+        self.setWindowFlag(Qt.WindowTransparentForInput, locked) 
+    
+    def __toggle_vr_comp(self, vr_comp: bool):
+        """Toggle widget VR compatibility"""
+        self.setWindowFlag(Qt.Tool, not vr_comp)
 
     def __connect_signal(self):
         """Connect overlay lock and hide signal"""
         self.state.locked.connect(self.__toggle_lock)
         self.state.hidden.connect(self.setHidden)
+        self.state.vr_comp.connect(self.__toggle_vr_comp)
 
     def __break_signal(self):
         """Disconnect overlay lock and hide signal"""
         self.state.locked.disconnect(self.__toggle_lock)
         self.state.hidden.disconnect(self.setHidden)
+        self.state.vr_comp.disconnect(self.__toggle_vr_comp)
 
     # Common GUI methods
     @staticmethod


### PR DESCRIPTION
Added VR compatibility toggle to overlay settings that makes the widgets appear as windows so that they can be used with OpenKneeboard.

For reference see: https://www.youtube.com/watch?v=QuCWYXDIHNU

