### PR TITLE
VR workaround: minimizing overlay widgets to taskbar instead of hiding

### DIFF
--- a/tinypedal/template/setting_global.py
+++ b/tinypedal/template/setting_global.py
@@ -47,6 +47,7 @@ GLOBAL_DEFAULT = {
         "enable_translucent_background": True,
         "enable_window_position_correction": True,
         "enable_x11_platform_plugin_override": False,
+        "enable_overlay_minimizing_when_hidden": False,
         "global_bkg_color": "#000000",
         "multimedia_plugin_on_windows": "WMF",
     },


### PR DESCRIPTION
This PR attempts to add a workaround to a VR issues (specifically with OpenKneeboard) mentioned in #121.

## To rephrase the issue:

When overlay widgets are hidden, those widgets are no longer visible to some third party app (such as OpenKneeboard), which can result third party app to crash.

## What's not possible:

It is impossible to make all the content of a overlay widget completely transparent, because each overlay widget consists many small "widget" elements each with their own states and styling and rendering methods, it is not practical to make everything transparent within the widget without breaking the overlay, not to mention all the additional code complexity. So the suggestion to make "whole widget" transparent is not possible here.

## Alternatives:

This PR tries to workaround the widget hidden issue (disappearing) by minimizing overlay widget window instead of hiding them. This is done via "showMinimized" method.

To enable this workaround:

1. Fetch and run this PR, go to main window menu Config > Compatibility, open Compatibility dialog, then check on "enable_overlay_minimizing_when_hidden" option and save. Note, this option is design to only take effect while "vr_compatibility" enabled.
2. Enable "VR compatibility" from Overlay menu.

Now, when auto hide is triggered, widgets will be minimized to taskbar instead of hiding, so in theory, all widgets will still be visible to other third party apps.

However, there are a few issues and limitations:

1. It is unknown whether this minimizing actually works under VR and "OpenKneeboard". (since I don't have VR, and never used "OpenKneeboard", there is no way I can test this.)

2. Minimizing required each widget (top-level window) must not use "stay on top" flag, this means widgets can lose focus and hide behind other windows. I can only assume that third party apps like "OpenKneeboard" will probably project those widget windows "always on top" of the game, which makes this not an issue (otherwise it will be useless).

3. There were some discussion mentioned that minimizing may not work on some system, such as on some Linux DE. Again, I cannot test this. @berarma probably can give it a try.

4. You can still Alt-Tab and click-on a minimizied widget, which will make the widget "active" and not "auto-hide".

Other solutions:

Another solution could be to move all widgets position to off-screen, such as as x-99999, y-99999. However, it is unknown if that would work with VR projection and view range, or result other issues.

## Final note:

"VR compatibility mode" was initially implemented by @TiberiuC39, and since has been used by many with "OpenKneeboard", and so far no one has reported similar issue. So for those having issues, consider seek help from others who doesn't have crash issue with "OpenKneeboard".

Strictly speaking, the issue as mentioned above, is not an issue of this APP, but rather an issue with third party apps. It is best to seek help and resolve them from those third party apps instead.

This PR may not be merged unless it is proved to be useful.

Good luck.