### PR TITLE
Refactor UserConfig: sectioned multi-column responsive layout for config dialog

### DIFF
--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -27,8 +27,8 @@ import re
 import time
 from typing import Callable
 
-from PySide2.QtCore import QPoint, Qt
-from PySide2.QtGui import QFontDatabase
+from PySide2.QtCore import QPoint, Qt, QTimer
+from PySide2.QtGui import QFontDatabase, QKeySequence
 from PySide2.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -280,7 +280,7 @@ class FontConfig(BaseDialog):
 
 @singleton_dialog(ConfigType.CONFIG)
 class UserConfig(BaseDialog):
-    """User configuration dialog with sectioned layout."""
+    """User configuration dialog with sectioned layout and search bar."""
 
     def __init__(
         self,
@@ -315,7 +315,13 @@ class UserConfig(BaseDialog):
         self.option_width = UIScaler.size(option_width)
         self.section_grouper = section_grouper or SectionGrouper()
 
-        # Option dict (key: option editor)
+        # Cache for current editor values (unsaved changes)
+        self.original_keys = list(self.user_setting[self.key_name])
+        self._current_values = {
+            key: self.user_setting[self.key_name][key] for key in self.original_keys
+        }
+
+        # Option dicts (key: option editor)
         self.option_bool: dict = {}
         self.option_color: dict = {}
         self.option_path: dict = {}
@@ -330,7 +336,21 @@ class UserConfig(BaseDialog):
         self._num_columns = 0
         self._widest_section = 0
 
-        # Button
+        # Search bar
+        search_layout = QHBoxLayout()
+        search_layout.addWidget(QLabel("Search:"))
+        self.search_edit = QLineEdit()
+        self.search_edit.setPlaceholderText("Type to filter options (Ctrl+F)")
+        self.search_edit.setClearButtonEnabled(True)
+        self.search_edit.textChanged.connect(self._on_search_text_changed)
+        search_layout.addWidget(self.search_edit)
+
+        # Debounce timer
+        self.filter_timer = QTimer()
+        self.filter_timer.setSingleShot(True)
+        self.filter_timer.timeout.connect(self._apply_filter)
+
+        # Buttons
         button_reset = QDialogButtonBox(QDialogButtonBox.Reset)
         button_reset.clicked.connect(self.reset_setting)
 
@@ -341,18 +361,19 @@ class UserConfig(BaseDialog):
         button_save.accepted.connect(self.saving)
         button_save.rejected.connect(self.reject)
 
-        # Create options
-        option_box = self._build_sectioned_layout()
+        # Create options (initial unfiltered view)
+        option_box = self._build_sectioned_layout(self.original_keys)
 
         # Create scroll box
         scroll_box = QScrollArea(self)
         scroll_box.setWidget(option_box)
         scroll_box.setWidgetResizable(True)
-        self._scroll_box = scroll_box  # keep reference for dynamic column reflow
+        self._scroll_box = scroll_box
 
-        # Set layout
+        # Set main layout
         layout_main = QVBoxLayout()
         layout_button = QHBoxLayout()
+        layout_main.addLayout(search_layout)
         layout_main.addWidget(scroll_box)
         layout_button.addWidget(button_reset)
         layout_button.addStretch(1)
@@ -377,50 +398,110 @@ class UserConfig(BaseDialog):
         if new_w != self.width() or new_h != self.height():
             self.resize(new_w, new_h)
 
+    # -------------------- Search / Filter --------------------
+    def _on_search_text_changed(self):
+        """Restart the debounce timer when text changes."""
+        self.filter_timer.start(200)  # milliseconds
+
+    def _apply_filter(self):
+        """Rebuild layout with keys that match the current filter text."""
+        text = self.search_edit.text().strip().lower()
+        if not text:
+            filtered_keys = self.original_keys
+        else:
+            filtered_keys = [key for key in self.original_keys if text in key.lower()]
+        self.rebuild_filtered_layout(filtered_keys)
+
+    def rebuild_filtered_layout(self, keys: list[str]):
+        """Rebuild the sectioned layout using only the given keys."""
+        # Clear old option dictionaries
+        self.option_bool.clear()
+        self.option_color.clear()
+        self.option_path.clear()
+        self.option_image.clear()
+        self.option_droplist.clear()
+        self.option_string.clear()
+        self.option_integer.clear()
+        self.option_float.clear()
+
+        # Group the filtered keys and create new section frames
+        sections = self.section_grouper.group_keys(keys)
+        self._section_widgets = [
+            self._create_section_frame(title, sec_keys)
+            for title, sec_keys in sections
+        ]
+
+        # Recalculate widest section for column layout
+        self._widest_section = max(
+            (w.sizeHint().width() for w in self._section_widgets), default=1
+        )
+
+        # Rearrange columns using the current column count
+        new_container = self._arrange_columns(self._num_columns)
+        self._scroll_box.setWidget(new_container)
+
+    # -------------------- Value cache --------------------
+    def _update_current_value(self, key, value):
+        """Update the central value cache when an editor changes."""
+        self._current_values[key] = value
+
+    # -------------------- Editor creation --------------------
     def _create_editor_for_key(self, key: str) -> QWidget:
-        """Create and register an editor widget for the given key."""
-        user_val = self.user_setting[self.key_name][key]
+        """Create and register an editor widget for the given key, using cached value."""
+        current_val = self._current_values[key]
         default_val = self.default_setting[self.key_name][key]
 
         # Bool
         if re.search(rxp.CFG_BOOL, key):
             editor = QCheckBox(self)
             editor.setFixedWidth(self.option_width)
-            editor.setChecked(user_val)
+            editor.setChecked(current_val)
             editor.defaults = default_val
+            editor.stateChanged.connect(
+                lambda state, k=key: self._update_current_value(k, state == Qt.Checked)
+            )
             add_context_menu(editor)
             self.option_bool[key] = editor
             return editor
 
         # Color string
         if re.search(rxp.CFG_COLOR, key):
-            editor = DoubleClickEdit(self, mode="color", init=user_val)
+            editor = DoubleClickEdit(self, mode="color", init=current_val)
             editor.setFixedWidth(self.option_width)
             editor.setMaxLength(9)
             editor.setValidator(QVAL_COLOR)
             editor.textChanged.connect(editor.preview_color)
-            editor.setText(user_val)
+            editor.setText(current_val)
             editor.defaults = default_val
+            editor.textChanged.connect(
+                lambda text, k=key: self._update_current_value(k, text)
+            )
             add_context_menu(editor)
             self.option_color[key] = editor
             return editor
 
         # User path string
         if re.search(rxp.CFG_USER_PATH, key):
-            editor = DoubleClickEdit(self, mode="path", init=user_val)
+            editor = DoubleClickEdit(self, mode="path", init=current_val)
             editor.setFixedWidth(self.option_width)
-            editor.setText(user_val)
+            editor.setText(current_val)
             editor.defaults = default_val
+            editor.textChanged.connect(
+                lambda text, k=key: self._update_current_value(k, text)
+            )
             add_context_menu(editor)
             self.option_path[key] = editor
             return editor
 
         # User image file path string
         if re.search(rxp.CFG_USER_IMAGE, key):
-            editor = DoubleClickEdit(self, mode="image", init=user_val)
+            editor = DoubleClickEdit(self, mode="image", init=current_val)
             editor.setFixedWidth(self.option_width)
-            editor.setText(user_val)
+            editor.setText(current_val)
             editor.defaults = default_val
+            editor.textChanged.connect(
+                lambda text, k=key: self._update_current_value(k, text)
+            )
             add_context_menu(editor)
             self.option_image[key] = editor
             return editor
@@ -430,8 +511,11 @@ class UserConfig(BaseDialog):
             editor = QComboBox(self)
             editor.setFixedWidth(self.option_width)
             editor.addItems(get_font_list())
-            editor.setCurrentText(str(user_val))
+            editor.setCurrentText(str(current_val))
             editor.defaults = default_val
+            editor.currentTextChanged.connect(
+                lambda text, k=key: self._update_current_value(k, text)
+            )
             add_context_menu(editor)
             self.option_droplist[key] = editor
             return editor
@@ -441,8 +525,11 @@ class UserConfig(BaseDialog):
             editor = QComboBox(self)
             editor.setFixedWidth(self.option_width)
             editor.addItems(cfg.user.heatmap.keys())
-            editor.setCurrentText(str(user_val))
+            editor.setCurrentText(str(current_val))
             editor.defaults = default_val
+            editor.currentTextChanged.connect(
+                lambda text, k=key: self._update_current_value(k, text)
+            )
             add_context_menu(editor)
             self.option_droplist[key] = editor
             return editor
@@ -453,8 +540,11 @@ class UserConfig(BaseDialog):
                 editor = QComboBox(self)
                 editor.setFixedWidth(self.option_width)
                 editor.addItems(choice_list)
-                editor.setCurrentText(str(user_val))
+                editor.setCurrentText(str(current_val))
                 editor.defaults = default_val
+                editor.currentTextChanged.connect(
+                    lambda text, k=key: self._update_current_value(k, text)
+                )
                 add_context_menu(editor)
                 self.option_droplist[key] = editor
                 return editor
@@ -464,8 +554,11 @@ class UserConfig(BaseDialog):
                 editor = QComboBox(self)
                 editor.setFixedWidth(self.option_width)
                 editor.addItems(choice_list)
-                editor.setCurrentText(str(user_val))
+                editor.setCurrentText(str(current_val))
                 editor.defaults = default_val
+                editor.currentTextChanged.connect(
+                    lambda text, k=key: self._update_current_value(k, text)
+                )
                 add_context_menu(editor)
                 self.option_droplist[key] = editor
                 return editor
@@ -474,8 +567,11 @@ class UserConfig(BaseDialog):
         if re.search(rxp.CFG_CLOCK_FORMAT, key) or re.search(rxp.CFG_STRING, key):
             editor = QLineEdit(self)
             editor.setFixedWidth(self.option_width)
-            editor.setText(user_val)
+            editor.setText(current_val)
             editor.defaults = default_val
+            editor.textChanged.connect(
+                lambda text, k=key: self._update_current_value(k, text)
+            )
             add_context_menu(editor)
             self.option_string[key] = editor
             return editor
@@ -485,8 +581,11 @@ class UserConfig(BaseDialog):
             editor = QLineEdit(self)
             editor.setFixedWidth(self.option_width)
             editor.setValidator(QVAL_INTEGER)
-            editor.setText(str(user_val))
+            editor.setText(str(current_val))
             editor.defaults = default_val
+            editor.textChanged.connect(
+                lambda text, k=key: self._update_current_value(k, text)
+            )
             add_context_menu(editor)
             self.option_integer[key] = editor
             return editor
@@ -495,12 +594,16 @@ class UserConfig(BaseDialog):
         editor = QLineEdit(self)
         editor.setFixedWidth(self.option_width)
         editor.setValidator(QVAL_FLOAT)
-        editor.setText(str(user_val))
+        editor.setText(str(current_val))
         editor.defaults = default_val
+        editor.textChanged.connect(
+            lambda text, k=key: self._update_current_value(k, text)
+        )
         add_context_menu(editor)
         self.option_float[key] = editor
         return editor
 
+    # -------------------- Layout building --------------------
     def _create_section_frame(self, title: str | None, keys: list) -> QFrame:
         """Create a frame containing one section with title bar and alternating rows."""
         layout = QGridLayout()
@@ -560,9 +663,8 @@ class UserConfig(BaseDialog):
         frame.setProperty("estimated_rows", len(keys) + (1 if title is not None else 0))
         return frame
 
-    def _build_sectioned_layout(self) -> QWidget:
+    def _build_sectioned_layout(self, keys: list[str]) -> QWidget:
         """Create section frames and arrange them for initial display."""
-        keys = list(self.user_setting[self.key_name])
         sections = self.section_grouper.group_keys(keys)
 
         self._section_widgets = [
@@ -622,6 +724,7 @@ class UserConfig(BaseDialog):
         container.setLayout(main_layout)
         return container
 
+    # -------------------- Resize event --------------------
     def resizeEvent(self, event):
         """Reflow columns when the window becomes wide or narrow enough."""
         super().resizeEvent(event)
@@ -632,6 +735,17 @@ class UserConfig(BaseDialog):
         if new_num != self._num_columns:
             self._scroll_box.setWidget(self._arrange_columns(new_num))
 
+    # -------------------- Focus searchbar --------------------
+    def keyPressEvent(self, event):
+        """Vang Ctrl+F af om focus naar de zoekbalk te verplaatsen."""
+        if event.matches(QKeySequence.Find):
+            self.search_edit.setFocus()
+            self.search_edit.selectAll()
+            event.accept()
+        else:
+            super().keyPressEvent(event)
+
+    # -------------------- Apply / Save / Reset --------------------
     def applying(self):
         """Save & apply"""
         self.save_setting(is_apply=True)
@@ -641,39 +755,56 @@ class UserConfig(BaseDialog):
         self.save_setting(is_apply=False)
 
     def reset_setting(self):
-        """Reset setting"""
+        """Reset setting to default values (and update cache)."""
         msg_text = (
             f"Reset all <b>{format_option_name(self.key_name)}</b> options to default?<br><br>"
             "Changes are only saved after clicking Apply or Save Button."
         )
         if self.confirm_operation(title="Reset Options", message=msg_text):
-            for editor in self.option_bool.values():
-                editor.setChecked(editor.defaults)
-            for editor in self.option_color.values():
-                editor.setText(editor.defaults)
-            for editor in self.option_path.values():
-                editor.setText(editor.defaults)
-            for editor in self.option_image.values():
-                editor.setText(editor.defaults)
-            for editor in self.option_droplist.values():
-                editor.setCurrentText(str(editor.defaults))
-            for editor in self.option_string.values():
-                editor.setText(editor.defaults)
-            for editor in self.option_integer.values():
-                editor.setText(str(editor.defaults))
-            for editor in self.option_float.values():
-                editor.setText(str(editor.defaults))
+            for key, editor in self.option_bool.items():
+                default = editor.defaults
+                editor.setChecked(default)
+                self._current_values[key] = default
+            for key, editor in self.option_color.items():
+                default = editor.defaults
+                editor.setText(default)
+                self._current_values[key] = default
+            for key, editor in self.option_path.items():
+                default = editor.defaults
+                editor.setText(default)
+                self._current_values[key] = default
+            for key, editor in self.option_image.items():
+                default = editor.defaults
+                editor.setText(default)
+                self._current_values[key] = default
+            for key, editor in self.option_droplist.items():
+                default = str(editor.defaults)
+                editor.setCurrentText(default)
+                self._current_values[key] = default
+            for key, editor in self.option_string.items():
+                default = editor.defaults
+                editor.setText(default)
+                self._current_values[key] = default
+            for key, editor in self.option_integer.items():
+                default = str(editor.defaults)
+                editor.setText(default)
+                self._current_values[key] = int(default) if default.isdigit() else default
+            for key, editor in self.option_float.items():
+                default = str(editor.defaults)
+                editor.setText(default)
+                self._current_values[key] = float(default) if '.' in default else int(default)
 
     def save_setting(self, is_apply: bool):
-        """Save setting"""
+        """Save setting from current cache, validate, and write to config."""
         user_setting = self.user_setting[self.key_name]
         error_found = False
 
+        # Validate and copy cached values into user_setting
         for key, editor in self.option_bool.items():
-            user_setting[key] = editor.isChecked()
+            user_setting[key] = self._current_values[key]
 
         for key, editor in self.option_color.items():
-            value = editor.text()
+            value = self._current_values[key]
             if is_hex_color(value):
                 user_setting[key] = value
             else:
@@ -681,23 +812,26 @@ class UserConfig(BaseDialog):
                 error_found = True
 
         for key, editor in self.option_path.items():
+            value = self._current_values[key]
             # Try convert to relative path again, in case user manually sets path
-            value = set_relative_path(editor.text())
+            value = set_relative_path(value)
             if set_user_data_path(value):
                 user_setting[key] = value
-                editor.setText(value)  # update reformatted path
+                # Update editor and cache to the reformatted path
+                editor.setText(value)
+                self._current_values[key] = value
             else:
                 self.value_error_message("path", key)
                 error_found = True
 
         for key, editor in self.option_image.items():
-            user_setting[key] = editor.text()
+            user_setting[key] = self._current_values[key]
 
         for key, editor in self.option_droplist.items():
-            user_setting[key] = editor.currentText()
+            user_setting[key] = self._current_values[key]
 
         for key, editor in self.option_string.items():
-            value = editor.text()
+            value = self._current_values[key]
             if re.search(rxp.CFG_CLOCK_FORMAT, key) and not is_clock_format(value):
                 self.value_error_message("clock format", key)
                 error_found = True
@@ -705,20 +839,23 @@ class UserConfig(BaseDialog):
             user_setting[key] = value
 
         for key, editor in self.option_integer.items():
-            value = editor.text()
-            if is_string_number(value):
-                user_setting[key] = int(value)
+            value = self._current_values[key]
+            # Ensure it's a string for validation, then convert back
+            str_val = str(value)
+            if is_string_number(str_val):
+                user_setting[key] = int(str_val)
             else:
                 self.value_error_message("number", key)
                 error_found = True
 
         for key, editor in self.option_float.items():
-            value = editor.text()
-            if is_string_number(value):
-                value = float(value)
-                if value % 1 == 0:  # remove unnecessary decimal points
-                    value = int(value)
-                user_setting[key] = value
+            value = self._current_values[key]
+            str_val = str(value)
+            if is_string_number(str_val):
+                num_val = float(str_val)
+                if num_val % 1 == 0:  # remove unnecessary decimal points
+                    num_val = int(num_val)
+                user_setting[key] = num_val
             else:
                 self.value_error_message("number", key)
                 error_found = True

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -30,7 +30,6 @@ from typing import Callable
 from PySide2.QtCore import QPoint, Qt, QTimer
 from PySide2.QtGui import QFontDatabase, QKeySequence, QShortcut
 from PySide2.QtWidgets import (
-    QAbstractItemView,
     QApplication,
     QCheckBox,
     QComboBox,
@@ -40,8 +39,6 @@ from PySide2.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
-    QListWidget,
-    QListWidgetItem,
     QMenu,
     QMessageBox,
     QScrollArea,
@@ -58,6 +55,7 @@ from ..setting import cfg
 from ..userfile import set_relative_path, set_user_data_path
 from ..validator import is_clock_format, is_hex_color, is_string_number
 from .config_preview import WidgetPreview
+from .dragdroplist import DragDropOrderList
 from ._common import (
     QVAL_COLOR,
     QVAL_FLOAT,
@@ -69,6 +67,7 @@ from ._common import (
 )
 
 COLUMN_LABEL = 0  # grid layout column index
+EDITOR_HEIGHT = UIScaler.size(2.2)
 
 
 def get_font_list() -> list[str]:
@@ -150,79 +149,6 @@ class SectionGrouper:
             sections.append((title, fkeys))
 
         return sections
-
-
-class ColumnIndexList(QListWidget):
-    """Drag-and-drop list for setting display order of columns"""
-
-    def __init__(self, keys: list, current_values: dict, update_callback, parent=None):
-        super().__init__(parent)
-        self.setDragDropMode(QAbstractItemView.InternalMove)
-        self.setDefaultDropAction(Qt.MoveAction)
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setUniformItemSizes(True)
-        self.setAlternatingRowColors(True)
-        self.setSizeAdjustPolicy(QAbstractItemView.AdjustToContents)  # no nested scrollbar
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        h_pad = UIScaler.size(0.4)
-        v_pad = UIScaler.size(0.2)
-        self.setStyleSheet(f"""
-            QListWidget {{
-                border: none;
-                outline: none;
-            }}
-            QListWidget::item {{
-                padding: {v_pad}px {h_pad}px;
-            }}
-            QListWidget::item:selected {{
-                background-color: palette(highlight);
-                color: palette(highlighted-text);
-            }}
-        """)
-        self._update_callback = update_callback
-
-        sorted_keys = sorted(keys, key=lambda k: current_values.get(k, 999))
-        for key in sorted_keys:
-            label = format_option_name(key[len("column_index_"):])
-            item = QListWidgetItem()
-            item.setData(Qt.UserRole, key)
-            item.setData(Qt.UserRole + 1, label)
-            self.addItem(item)
-
-        self.model().rowsMoved.connect(self._sync_values)
-        self._sync_values()
-        self._fix_height()
-
-    def _fix_height(self):
-        """Set fixed height to show all items"""
-        v_pad = UIScaler.size(0.2)
-        row_h = self.fontMetrics().height() + v_pad * 2
-        self.setFixedHeight(row_h * self.count() + self.frameWidth() * 2)
-
-    def _sync_values(self):
-        """Update item text and value cache to reflect current order"""
-        for i in range(self.count()):
-            item = self.item(i)
-            label = item.data(Qt.UserRole + 1)
-            item.setText(f"{i + 1}. {label}")
-            self._update_callback(item.data(Qt.UserRole), i + 1)
-
-    def reset_to_defaults(self, default_values: dict):
-        """Re-sort items to default order"""
-        items = []
-        for i in range(self.count()):
-            item = self.item(i)
-            items.append((item.data(Qt.UserRole), item.data(Qt.UserRole + 1)))
-        items.sort(key=lambda t: default_values.get(t[0], 999))
-        self.clear()
-        for key, label in items:
-            new_item = QListWidgetItem()
-            new_item.setData(Qt.UserRole, key)
-            new_item.setData(Qt.UserRole + 1, label)
-            self.addItem(new_item)
-        self._sync_values()
-
 
 @singleton_dialog(ConfigType.CONFIG)
 class FontConfig(BaseDialog):
@@ -529,9 +455,12 @@ class UserConfig(BaseDialog):
         current_val = self._current_values[key]
         default_val = self.default_setting[self.key_name][key]
 
+        editor_height = EDITOR_HEIGHT
+
         # Bool
         if re.search(rxp.CFG_BOOL, key):
             editor = QCheckBox(self)
+            editor.setFixedHeight(editor_height)
             editor.setFixedWidth(self.option_width)
             editor.setChecked(current_val)
             editor.defaults = default_val
@@ -545,6 +474,7 @@ class UserConfig(BaseDialog):
         # Color string
         if re.search(rxp.CFG_COLOR, key):
             editor = DoubleClickEdit(self, mode="color", init=current_val)
+            editor.setFixedHeight(editor_height)
             editor.setFixedWidth(self.option_width)
             editor.setMaxLength(9)
             editor.setValidator(QVAL_COLOR)
@@ -561,6 +491,7 @@ class UserConfig(BaseDialog):
         # User path string
         if re.search(rxp.CFG_USER_PATH, key):
             editor = DoubleClickEdit(self, mode="path", init=current_val)
+            editor.setFixedHeight(editor_height)
             editor.setFixedWidth(self.option_width)
             editor.setText(current_val)
             editor.defaults = default_val
@@ -574,6 +505,7 @@ class UserConfig(BaseDialog):
         # User image file path string
         if re.search(rxp.CFG_USER_IMAGE, key):
             editor = DoubleClickEdit(self, mode="image", init=current_val)
+            editor.setFixedHeight(editor_height)
             editor.setFixedWidth(self.option_width)
             editor.setText(current_val)
             editor.defaults = default_val
@@ -587,6 +519,7 @@ class UserConfig(BaseDialog):
         # Font name string
         if re.search(rxp.CFG_FONT_NAME, key):
             editor = QComboBox(self)
+            editor.setFixedHeight(editor_height)
             editor.setFixedWidth(self.option_width)
             editor.addItems(get_font_list())
             editor.setCurrentText(str(current_val))
@@ -601,6 +534,7 @@ class UserConfig(BaseDialog):
         # Heatmap string
         if re.search(rxp.CFG_HEATMAP, key):
             editor = QComboBox(self)
+            editor.setFixedHeight(editor_height)
             editor.setFixedWidth(self.option_width)
             editor.addItems(cfg.user.heatmap.keys())
             editor.setCurrentText(str(current_val))
@@ -616,6 +550,7 @@ class UserConfig(BaseDialog):
         for ref_key, choice_list in rxp.CHOICE_UNITS.items():
             if re.search(ref_key, key):
                 editor = QComboBox(self)
+                editor.setFixedHeight(editor_height)
                 editor.setFixedWidth(self.option_width)
                 editor.addItems(choice_list)
                 editor.setCurrentText(str(current_val))
@@ -630,6 +565,7 @@ class UserConfig(BaseDialog):
         for ref_key, choice_list in rxp.CHOICE_COMMON.items():
             if re.search(ref_key, key):
                 editor = QComboBox(self)
+                editor.setFixedHeight(editor_height)
                 editor.setFixedWidth(self.option_width)
                 editor.addItems(choice_list)
                 editor.setCurrentText(str(current_val))
@@ -644,6 +580,7 @@ class UserConfig(BaseDialog):
         # Clock format string
         if re.search(rxp.CFG_CLOCK_FORMAT, key) or re.search(rxp.CFG_STRING, key):
             editor = QLineEdit(self)
+            editor.setFixedHeight(editor_height)
             editor.setFixedWidth(self.option_width)
             editor.setText(current_val)
             editor.defaults = default_val
@@ -657,6 +594,7 @@ class UserConfig(BaseDialog):
         # Integer
         if re.search(rxp.CFG_INTEGER, key):
             editor = QLineEdit(self)
+            editor.setFixedHeight(editor_height)
             editor.setFixedWidth(self.option_width)
             editor.setValidator(QVAL_INTEGER)
             editor.setText(str(current_val))
@@ -670,6 +608,7 @@ class UserConfig(BaseDialog):
 
         # Float or int (fallback)
         editor = QLineEdit(self)
+        editor.setFixedHeight(editor_height)
         editor.setFixedWidth(self.option_width)
         editor.setValidator(QVAL_FLOAT)
         editor.setText(str(current_val))
@@ -683,6 +622,7 @@ class UserConfig(BaseDialog):
 
     def _create_column_index_frame(self, title: str | None, keys: list) -> QFrame:
         """Create drag-and-drop frame for display order settings"""
+
         layout = QVBoxLayout()
         layout.setAlignment(Qt.AlignTop)
         layout.setSpacing(0)
@@ -704,17 +644,36 @@ class UserConfig(BaseDialog):
             """)
             layout.addWidget(title_label)
 
-        list_widget = ColumnIndexList(
-            keys, self._current_values, self._update_current_value, parent=self
+        sorted_keys = sorted(
+            keys,
+            key=lambda k: self._current_values.get(k, 999)
+        )
+        items = [
+            (key, format_option_name(key[len("column_index_"):]))
+            for key in sorted_keys
+        ]
+
+        def on_reorder(new_order):
+            for index, key in enumerate(new_order, start=1):
+                self._update_current_value(key, index)
+
+        row_height = EDITOR_HEIGHT + 2 * UIScaler.size(0.2)
+        list_widget = DragDropOrderList(
+            items=items,
+            on_reorder_callback=on_reorder,
+            row_height=row_height,
+            parent=self
         )
         for key in keys:
             self.option_column_order[key] = list_widget
+
         layout.addWidget(list_widget)
 
         frame = QFrame()
         frame.setObjectName("sectionFrame")
         frame.setLayout(layout)
         frame.setProperty("estimated_rows", len(keys) + (2 if title is not None else 1))
+
         return frame
 
     def _create_section_frame(self, title: str | None, keys: list) -> QFrame:
@@ -843,11 +802,20 @@ class UserConfig(BaseDialog):
         container.setLayout(main_layout)
         return container
 
-    def closeEvent(self, event):
-        """Stop all timers before Qt tears down child widgets"""
+    def _cleanup(self):
+        """Stop timers and release preview resources"""
         self.filter_timer.stop()
         if self._preview is not None:
             self._preview.cleanup()
+
+    def reject(self):
+        """Cancel / ESC"""
+        self._cleanup()
+        super().reject()
+
+    def closeEvent(self, event):
+        """Stop all timers before Qt tears down child widgets"""
+        self._cleanup()
         super().closeEvent(event)
 
     def resizeEvent(self, event):

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -22,27 +22,23 @@ Config dialog
 
 from __future__ import annotations
 
-import os
+import logging
 import re
 import time
 from typing import Callable
 
-from PySide2.QtCore import QPoint, Qt, QTimer
-from PySide2.QtGui import QFontDatabase, QKeySequence, QShortcut
+from PySide2.QtCore import Qt, QTimer
+from PySide2.QtGui import QKeySequence, QShortcut
 from PySide2.QtWidgets import (
-    QApplication,
     QCheckBox,
     QComboBox,
     QDialogButtonBox,
     QFrame,
-    QGridLayout,
     QHBoxLayout,
     QLabel,
     QLineEdit,
-    QMenu,
     QMessageBox,
     QScrollArea,
-    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
@@ -53,222 +49,23 @@ from ..formatter import format_option_name
 from ..setting import cfg
 from ..userfile import set_relative_path, set_user_data_path
 from ..validator import is_clock_format, is_hex_color, is_string_number
+from ._common import BaseDialog, UIScaler, singleton_dialog
 from .config_preview import WidgetPreview
 from .dragdroplist import DragDropOrderList
-from ._common import (
-    QVAL_COLOR,
-    QVAL_FLOAT,
-    QVAL_INTEGER,
-    BaseDialog,
-    DoubleClickEdit,
-    UIScaler,
-    singleton_dialog,
-)
+from .section_grouper import SectionGrouper
+from .section_builder import SectionBuilder
 
-COLUMN_LABEL = 0  # grid layout column index
+logger = logging.getLogger(__name__)
+
+COLUMN_LABEL = 0
 EDITOR_HEIGHT = UIScaler.size(2.2)
 
 
-def get_font_list() -> list[str]:
-    """Get all available font families list"""
-    if os.getenv("PYSIDE_OVERRIDE") == "6":  # no instance in qt6
-        return QFontDatabase.families()  # type: ignore[call-arg]
-    return QFontDatabase().families()
-
-
-class SectionGrouper:
-    """Groups configuration keys into labelled sections by word overlap"""
-
-    def __init__(self, min_match: int = 2):
-        self.min_match = min_match
-
-    @staticmethod
-    def _word_set(phrase: str) -> set[str]:
-        """Split underscore-delimited name into word set"""
-        return set(phrase.split("_"))
-
-    def _similar(self, topic1: str, topic2: str) -> bool:
-        """Check if two topics share enough words to belong in one section"""
-        # Direct match if one is a substring of the other
-        if topic1 in topic2 or topic2 in topic1:
-            return True
-        words1 = self._word_set(topic1)
-        words2 = self._word_set(topic2)
-        return len(words1 & words2) >= self.min_match
-
-    def group_keys(self, keys: list[str]) -> list[tuple[str | None, list[str]]]:
-        """Group keys into labelled sections, returns list of (title, key_list) tuples"""
-        # Separate column_index_* into its own group
-        fixed_groups: dict[str, list[str]] = {}
-        remaining: list[str] = []
-        for key in keys:
-            if key.startswith("column_index_"):
-                fixed_groups.setdefault("Column Index", []).append(key)
-            else:
-                remaining.append(key)
-
-        # Build sections from remaining keys
-        sections: list[tuple[str | None, list[str]]] = []
-        current_title: str | None = None
-        current_keys: list[str] = []
-        last_show: str | None = None
-
-        for key in remaining:
-            if key.startswith("show_"):
-                topic = key[5:]  # strip 'show_' prefix
-                if last_show is None:
-                    current_title = topic
-                    current_keys = [key]
-                    last_show = topic
-                elif self._similar(last_show, topic):
-                    current_keys.append(key)
-                    last_show = topic
-                else:
-                    sections.append((current_title, current_keys))
-                    current_title = topic
-                    current_keys = [key]
-                    last_show = topic
-            elif current_title is not None:
-                current_keys.append(key)
-
-        # Add last open section
-        if current_keys:
-            sections.append((current_title, current_keys))
-
-        # Collect keys that appeared before the first show_* key
-        all_assigned: set[str] = set()
-        for _, key_list in sections:
-            all_assigned.update(key_list)
-        unassigned = [k for k in remaining if k not in all_assigned]
-        if unassigned:
-            sections.insert(0, ("", unassigned))
-
-        # Append fixed groups
-        for title, fkeys in fixed_groups.items():
-            sections.append((title, fkeys))
-
-        return sections
-
-@singleton_dialog(ConfigType.CONFIG)
-class FontConfig(BaseDialog):
-    """Config global font setting"""
-
-    def __init__(self, parent, user_setting: dict, reload_func: Callable):
-        super().__init__(parent)
-        self.set_config_title("Global Font Override", cfg.filename.setting)
-
-        self.reloading = reload_func
-        self.user_setting = user_setting
-
-        # Combobox
-        self.edit_fontname = QComboBox(self)
-        self.edit_fontname.addItem("no change")
-        self.edit_fontname.addItems(get_font_list())
-        self.edit_fontname.setFixedWidth(UIScaler.size(9))
-
-        self.edit_fontsize = QSpinBox(self)
-        self.edit_fontsize.setRange(-999, 999)
-        self.edit_fontsize.setFixedWidth(UIScaler.size(9))
-
-        self.edit_fontweight = QComboBox(self)
-        self.edit_fontweight.addItem("no change")
-        self.edit_fontweight.addItems(rxp.CHOICE_COMMON[rxp.CFG_FONT_WEIGHT])
-        self.edit_fontweight.setFixedWidth(UIScaler.size(9))
-
-        self.edit_autooffset = QComboBox(self)
-        self.edit_autooffset.addItems(("no change", "enable", "disable"))
-        self.edit_autooffset.setFixedWidth(UIScaler.size(9))
-
-        self.edit_fontoffset = QSpinBox(self)
-        self.edit_fontoffset.setRange(-999, 999)
-        self.edit_fontoffset.setFixedWidth(UIScaler.size(9))
-
-        layout_option = QGridLayout()
-        layout_option.setAlignment(Qt.AlignTop)
-        layout_option.addWidget(QLabel("Font Name"), 0, 0)
-        layout_option.addWidget(self.edit_fontname, 0, 1)
-        layout_option.addWidget(QLabel("Font Size Addend"), 1, 0)
-        layout_option.addWidget(self.edit_fontsize, 1, 1)
-        layout_option.addWidget(QLabel("Font Weight"), 2, 0)
-        layout_option.addWidget(self.edit_fontweight, 2, 1)
-        layout_option.addWidget(QLabel("Enable Auto Font Offset"), 3, 0)
-        layout_option.addWidget(self.edit_autooffset, 3, 1)
-        layout_option.addWidget(QLabel("Font Offset Vertical Addend"), 4, 0)
-        layout_option.addWidget(self.edit_fontoffset, 4, 1)
-
-        # Button
-        button_apply = QDialogButtonBox(QDialogButtonBox.Apply)
-        button_apply.clicked.connect(self.applying)
-
-        button_save = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
-        button_save.accepted.connect(self.saving)
-        button_save.rejected.connect(self.reject)
-
-        layout_button = QHBoxLayout()
-        layout_button.addStretch(1)
-        layout_button.addWidget(button_apply)
-        layout_button.addWidget(button_save)
-
-        # Set layout
-        layout_main = QVBoxLayout()
-        layout_main.addLayout(layout_option)
-        layout_main.addLayout(layout_button)
-        layout_main.setContentsMargins(self.MARGIN, self.MARGIN, self.MARGIN, self.MARGIN)
-        self.setLayout(layout_main)
-
-    def applying(self):
-        """Save & apply"""
-        self.save_setting(self.user_setting)
-
-    def saving(self):
-        """Save & close"""
-        self.applying()
-        self.accept()  # close
-
-    def save_setting(self, dict_user: dict[str, dict]):
-        """Save setting"""
-        for setting in dict_user.values():
-            for key in setting:
-                # Font name
-                if re.search(rxp.CFG_FONT_NAME, key):
-                    font_name = self.edit_fontname.currentText()
-                    if font_name != "no change":
-                        setting[key] = font_name
-                    continue
-                # Font weight
-                if re.search(rxp.CFG_FONT_WEIGHT, key):
-                    font_weight = self.edit_fontweight.currentText()
-                    if font_weight != "no change":
-                        setting[key] = font_weight
-                    continue
-                # Font size addend
-                if re.search("font_size", key):
-                    font_size = self.edit_fontsize.value()
-                    if font_size != 0:
-                        setting[key] = max(setting[key] + font_size, 1)
-                    continue
-                # Auto font offset
-                if key == "enable_auto_font_offset":
-                    auto_offset = self.edit_autooffset.currentText()
-                    if auto_offset == "disable":
-                        setting[key] = False
-                    elif auto_offset == "enable":
-                        setting[key] = True
-                    continue
-                # Font offset vertical
-                if key == "font_offset_vertical":
-                    font_offset = self.edit_fontoffset.value()
-                    if font_offset != 0:
-                        setting[key] += font_offset
-                    continue
-        # Reset after applied
-        self.edit_fontsize.setValue(0)
-        self.edit_fontoffset.setValue(0)
-        cfg.save(0)
-        # Wait saving finish
-        while cfg.is_saving:
-            time.sleep(0.01)
-        self.reloading()
+def set_preset_name(cfg_type: str):
+    """Set preset name"""
+    if cfg_type == ConfigType.CONFIG:
+        return f"{cfg.filename.config} (global)"
+    return cfg.filename.setting
 
 
 @singleton_dialog(ConfigType.CONFIG)
@@ -304,28 +101,25 @@ class UserConfig(BaseDialog):
             key: self.user_setting[self.key_name][key] for key in self.original_keys
         }
 
-        # Option dicts (key: option editor)
-        self.option_bool: dict = {}
-        self.option_color: dict = {}
-        self.option_path: dict = {}
-        self.option_image: dict = {}
-        self.option_droplist: dict = {}
-        self.option_string: dict = {}
-        self.option_integer: dict = {}
-        self.option_float: dict = {}
-        self.option_column_order: dict = {}  # key -> ColumnIndexList widget
+        # Preview widget
         self._preview: WidgetPreview | None = None
 
-        # Row tracking for search dimming
-        self._row_widgets: dict[str, QWidget] = {}   # key -> row container
-        self._row_labels: dict[str, QLabel] = {}      # key -> label widget
-        self._section_title_widgets: list[tuple[QLabel, list[str]]] = []  # (title_label, keys)
-        self._column_order_widgets: dict[str, DragDropOrderList] = {}  # key -> list widget
+        # Row tracking for search dimming – will be populated by builder
+        self._row_widgets: dict[str, QWidget] = {}
+        self._row_labels: dict[str, QLabel] = {}
+        self._section_title_widgets: list[tuple[QLabel, list[str]]] = []
+        self._column_order_widgets: dict[str, DragDropOrderList] = {}
 
-        # Section widgets and current column count (used for dynamic reflow)
+        # Section widgets and current column count
+        self._general_frame: QFrame | None = None
         self._section_widgets: list[QFrame] = []
+        self._column_index_frames: list[QFrame] = []
         self._num_columns = 0
         self._widest_section = 0
+
+        # Voor sectie‑highlight en herordening
+        self._sections: list[tuple[str | None, list[str]]] = []   # opgeslagen gegroepeerde secties
+        self._highlighted_keys: set[str] = set()                  # momenteel gehighlighte keys
 
         # Search bar
         search_layout = QHBoxLayout()
@@ -336,11 +130,9 @@ class UserConfig(BaseDialog):
         self.search_edit.textChanged.connect(self._on_search_text_changed)
         search_layout.addWidget(self.search_edit)
 
-        # Ctrl+F shortcut: fires regardless of which child widget has focus
         shortcut_find = QShortcut(QKeySequence.Find, self)
         shortcut_find.activated.connect(self._focus_search)
 
-        # Debounce timer
         self.filter_timer = QTimer(self)
         self.filter_timer.setSingleShot(True)
         self.filter_timer.timeout.connect(self._apply_filter)
@@ -356,7 +148,14 @@ class UserConfig(BaseDialog):
         button_save.accepted.connect(self.saving)
         button_save.rejected.connect(self.reject)
 
-        # Create options (initial unfiltered view)
+        # Create builder and build sections
+        self.builder = SectionBuilder(
+            parent_dialog=self,
+            current_values=self._current_values,
+            update_callback=self._update_current_value,
+            option_width=self.option_width,
+            highlight_callback=self.highlight_section  # nieuwe callback voor klik op sectie
+        )
         option_box = self._build_sectioned_layout(self.original_keys)
 
         # Create scroll box
@@ -368,15 +167,32 @@ class UserConfig(BaseDialog):
         # Preview panel (only for widget configs)
         if cfg_type == ConfigType.WIDGET:
             self._preview = WidgetPreview(key_name, parent=self)
-        else:
-            self._preview = None
 
-        # Set main layout: Preview (top) → Search → Editor → Buttons
+        # Set main layout
         layout_main = QVBoxLayout()
         layout_button = QHBoxLayout()
-        if self._preview is not None and self._preview.available:
+
+        has_preview = self._preview is not None and self._preview.available
+        if has_preview:
             layout_main.addWidget(self._preview)
+
         layout_main.addLayout(search_layout)
+
+        if has_preview and (self._general_frame or self._column_index_frames):
+            controls_row = QHBoxLayout()
+            controls_row.setSpacing(self.MARGIN)
+            if self._general_frame is not None:
+                general_scroll = QScrollArea()
+                general_scroll.setWidget(self._general_frame)
+                general_scroll.setWidgetResizable(True)
+                controls_row.addWidget(general_scroll)
+            for frame in self._column_index_frames:
+                col_scroll = QScrollArea()
+                col_scroll.setWidget(frame)
+                col_scroll.setWidgetResizable(True)
+                controls_row.addWidget(col_scroll)
+            layout_main.addLayout(controls_row)
+
         layout_main.addWidget(scroll_box, 1)
         layout_button.addWidget(button_reset)
         layout_button.addStretch(1)
@@ -401,91 +217,8 @@ class UserConfig(BaseDialog):
         if new_w != self.width() or new_h != self.height():
             self.resize(new_w, new_h)
 
-    def _on_search_text_changed(self):
-        """Restart debounce timer"""
-        self.filter_timer.start(200)  # milliseconds
-
-    def _apply_filter(self):
-        """Dim non-matching rows based on the current filter text."""
-        text = self.search_edit.text().strip().lower()
-        if not text:
-            # Restore all rows
-            for key in self._row_widgets:
-                self._undim_row(key)
-            # Restore all drag-drop rows
-            seen: set[int] = set()
-            for lw in self._column_order_widgets.values():
-                if id(lw) not in seen:
-                    seen.add(id(lw))
-                    lw.set_dimmed_keys(set())
-            # Restore all section titles
-            for title_label, _ in self._section_title_widgets:
-                title_label.setStyleSheet("""
-                    background-color: palette(dark);
-                    color: palette(bright-text);
-                    border-bottom: 2px solid palette(mid);
-                    padding: 4px;
-                """)
-            return
-
-        # Dim/undim regular rows
-        for key in self._row_widgets:
-            if text in key.lower():
-                self._undim_row(key)
-            else:
-                self._dim_row(key)
-
-        # Dim/undim drag-drop rows
-        seen_lw: set[int] = set()
-        for lw in self._column_order_widgets.values():
-            if id(lw) not in seen_lw:
-                seen_lw.add(id(lw))
-                dimmed = set()
-                for k, w in self._column_order_widgets.items():
-                    if w is lw and text not in k.lower():
-                        dimmed.add(k)
-                lw.set_dimmed_keys(dimmed)
-
-        # Dim section titles when all their rows are dimmed
-        for title_label, keys in self._section_title_widgets:
-            all_dimmed = all(
-                text not in k.lower() for k in keys
-            )
-            if all_dimmed:
-                title_label.setStyleSheet("""
-                    background-color: palette(mid);
-                    color: palette(window);
-                    border-bottom: 2px solid palette(mid);
-                    padding: 4px;
-                """)
-            else:
-                title_label.setStyleSheet("""
-                    background-color: palette(dark);
-                    color: palette(bright-text);
-                    border-bottom: 2px solid palette(mid);
-                    padding: 4px;
-                """)
-
-    def _dim_row(self, key: str):
-        """Apply dim styling to a row widget and its label."""
-        row_widget = self._row_widgets.get(key)
-        label = self._row_labels.get(key)
-        if row_widget is None:
-            return
-        row_widget.setStyleSheet("background-color: palette(window);")
-        if label is not None:
-            label.setStyleSheet("color: palette(mid);")
-
-    def _undim_row(self, key: str):
-        """Restore original styling to a row widget and its label."""
-        row_widget = self._row_widgets.get(key)
-        label = self._row_labels.get(key)
-        if row_widget is None:
-            return
-        bg = row_widget.property("_base_bg") or "palette(base)"
-        row_widget.setStyleSheet(f"background-color: {bg};")
-        if label is not None:
-            label.setStyleSheet("")
+        # Initieel de secties sorteren volgens opgeslagen column_index_* waarden
+        self.reorder_sections()
 
     def _update_current_value(self, key, value):
         """Update value cache"""
@@ -493,326 +226,43 @@ class UserConfig(BaseDialog):
         if self._preview is not None:
             self._preview.schedule_refresh(self._current_values)
 
-    def _create_editor_for_key(self, key: str) -> QWidget:
-        """Create editor widget for key"""
-        current_val = self._current_values[key]
-        default_val = self.default_setting[self.key_name][key]
-
-        editor_height = EDITOR_HEIGHT
-
-        # Bool
-        if re.search(rxp.CFG_BOOL, key):
-            editor = QCheckBox(self)
-            editor.setFixedHeight(editor_height)
-            editor.setFixedWidth(self.option_width)
-            editor.setChecked(current_val)
-            editor.defaults = default_val
-            editor.stateChanged.connect(
-                lambda state, k=key: self._update_current_value(k, bool(state))
-            )
-            add_context_menu(editor)
-            self.option_bool[key] = editor
-            return editor
-
-        # Color string
-        if re.search(rxp.CFG_COLOR, key):
-            editor = DoubleClickEdit(self, mode="color", init=current_val)
-            editor.setFixedHeight(editor_height)
-            editor.setFixedWidth(self.option_width)
-            editor.setMaxLength(9)
-            editor.setValidator(QVAL_COLOR)
-            editor.textChanged.connect(editor.preview_color)
-            editor.setText(current_val)
-            editor.defaults = default_val
-            editor.textChanged.connect(
-                lambda text, k=key: self._update_current_value(k, text)
-            )
-            add_context_menu(editor)
-            self.option_color[key] = editor
-            return editor
-
-        # User path string
-        if re.search(rxp.CFG_USER_PATH, key):
-            editor = DoubleClickEdit(self, mode="path", init=current_val)
-            editor.setFixedHeight(editor_height)
-            editor.setFixedWidth(self.option_width)
-            editor.setText(current_val)
-            editor.defaults = default_val
-            editor.textChanged.connect(
-                lambda text, k=key: self._update_current_value(k, text)
-            )
-            add_context_menu(editor)
-            self.option_path[key] = editor
-            return editor
-
-        # User image file path string
-        if re.search(rxp.CFG_USER_IMAGE, key):
-            editor = DoubleClickEdit(self, mode="image", init=current_val)
-            editor.setFixedHeight(editor_height)
-            editor.setFixedWidth(self.option_width)
-            editor.setText(current_val)
-            editor.defaults = default_val
-            editor.textChanged.connect(
-                lambda text, k=key: self._update_current_value(k, text)
-            )
-            add_context_menu(editor)
-            self.option_image[key] = editor
-            return editor
-
-        # Font name string
-        if re.search(rxp.CFG_FONT_NAME, key):
-            editor = QComboBox(self)
-            editor.setFixedHeight(editor_height)
-            editor.setFixedWidth(self.option_width)
-            editor.addItems(get_font_list())
-            editor.setCurrentText(str(current_val))
-            editor.defaults = default_val
-            editor.currentTextChanged.connect(
-                lambda text, k=key: self._update_current_value(k, text)
-            )
-            add_context_menu(editor)
-            self.option_droplist[key] = editor
-            return editor
-
-        # Heatmap string
-        if re.search(rxp.CFG_HEATMAP, key):
-            editor = QComboBox(self)
-            editor.setFixedHeight(editor_height)
-            editor.setFixedWidth(self.option_width)
-            editor.addItems(cfg.user.heatmap.keys())
-            editor.setCurrentText(str(current_val))
-            editor.defaults = default_val
-            editor.currentTextChanged.connect(
-                lambda text, k=key: self._update_current_value(k, text)
-            )
-            add_context_menu(editor)
-            self.option_droplist[key] = editor
-            return editor
-
-        # Units choice list string
-        for ref_key, choice_list in rxp.CHOICE_UNITS.items():
-            if re.search(ref_key, key):
-                editor = QComboBox(self)
-                editor.setFixedHeight(editor_height)
-                editor.setFixedWidth(self.option_width)
-                editor.addItems(choice_list)
-                editor.setCurrentText(str(current_val))
-                editor.defaults = default_val
-                editor.currentTextChanged.connect(
-                    lambda text, k=key: self._update_current_value(k, text)
-                )
-                add_context_menu(editor)
-                self.option_droplist[key] = editor
-                return editor
-        # Common choice list string
-        for ref_key, choice_list in rxp.CHOICE_COMMON.items():
-            if re.search(ref_key, key):
-                editor = QComboBox(self)
-                editor.setFixedHeight(editor_height)
-                editor.setFixedWidth(self.option_width)
-                editor.addItems(choice_list)
-                editor.setCurrentText(str(current_val))
-                editor.defaults = default_val
-                editor.currentTextChanged.connect(
-                    lambda text, k=key: self._update_current_value(k, text)
-                )
-                add_context_menu(editor)
-                self.option_droplist[key] = editor
-                return editor
-
-        # Clock format string
-        if re.search(rxp.CFG_CLOCK_FORMAT, key) or re.search(rxp.CFG_STRING, key):
-            editor = QLineEdit(self)
-            editor.setFixedHeight(editor_height)
-            editor.setFixedWidth(self.option_width)
-            editor.setText(current_val)
-            editor.defaults = default_val
-            editor.textChanged.connect(
-                lambda text, k=key: self._update_current_value(k, text)
-            )
-            add_context_menu(editor)
-            self.option_string[key] = editor
-            return editor
-
-        # Integer
-        if re.search(rxp.CFG_INTEGER, key):
-            editor = QLineEdit(self)
-            editor.setFixedHeight(editor_height)
-            editor.setFixedWidth(self.option_width)
-            editor.setValidator(QVAL_INTEGER)
-            editor.setText(str(current_val))
-            editor.defaults = default_val
-            editor.textChanged.connect(
-                lambda text, k=key: self._update_current_value(k, text)
-            )
-            add_context_menu(editor)
-            self.option_integer[key] = editor
-            return editor
-
-        # Float or int (fallback)
-        editor = QLineEdit(self)
-        editor.setFixedHeight(editor_height)
-        editor.setFixedWidth(self.option_width)
-        editor.setValidator(QVAL_FLOAT)
-        editor.setText(str(current_val))
-        editor.defaults = default_val
-        editor.textChanged.connect(
-            lambda text, k=key: self._update_current_value(k, text)
-        )
-        add_context_menu(editor)
-        self.option_float[key] = editor
-        return editor
-
-    def _create_column_index_frame(self, title: str | None, keys: list) -> QFrame:
-        """Create drag-and-drop frame for display order settings"""
-
-        layout = QVBoxLayout()
-        layout.setAlignment(Qt.AlignTop)
-        layout.setSpacing(0)
-        layout.setContentsMargins(0, 0, 0, 0)
-
-        col_title_label = None
-        if title is not None:
-            header_text = (
-                format_option_name(self.key_name) if title == "" else "Display Order"
-            )
-            col_title_label = QLabel(f"<b>{header_text}</b>")
-            font = col_title_label.font()
-            font.setPointSize(font.pointSize() + 1)
-            col_title_label.setFont(font)
-            col_title_label.setStyleSheet("""
-                background-color: palette(dark);
-                color: palette(bright-text);
-                border-bottom: 2px solid palette(mid);
-                padding: 4px;
-            """)
-            layout.addWidget(col_title_label)
-
-        sorted_keys = sorted(
-            keys,
-            key=lambda k: self._current_values.get(k, 999)
-        )
-        items = [
-            (key, format_option_name(key[len("column_index_"):]))
-            for key in sorted_keys
-        ]
-
-        def on_reorder(new_order):
-            for index, key in enumerate(new_order, start=1):
-                self._update_current_value(key, index)
-
-        row_height = EDITOR_HEIGHT + 2 * UIScaler.size(0.2)
-        list_widget = DragDropOrderList(
-            items=items,
-            on_reorder_callback=on_reorder,
-            row_height=row_height,
-            parent=self
-        )
-        for key in keys:
-            self.option_column_order[key] = list_widget
-            self._column_order_widgets[key] = list_widget
-
-        layout.addWidget(list_widget)
-
-        if col_title_label is not None:
-            self._section_title_widgets.append((col_title_label, keys))
-
-        frame = QFrame()
-        frame.setObjectName("sectionFrame")
-        frame.setLayout(layout)
-        frame.setProperty("estimated_rows", len(keys) + (2 if title is not None else 1))
-
-        return frame
-
-    def _create_section_frame(self, title: str | None, keys: list) -> QFrame:
-        """Create section frame with title bar and alternating rows"""
-        # column_index_* keys get a drag-and-drop list instead of integer editors
-        if keys and all(k.startswith("column_index_") for k in keys):
-            return self._create_column_index_frame(title, keys)
-        layout = QGridLayout()
-        layout.setAlignment(Qt.AlignTop)
-        layout.setSpacing(0)
-        layout.setContentsMargins(0, 0, 0, 0)
-
-        row_offset = 0
-        if title is not None:
-            # Title bar
-            header_text = (
-                format_option_name(self.key_name)
-                if title == ""
-                else format_option_name(title)
-            )
-            title_label = QLabel(f"<b>{header_text}</b>")
-            font = title_label.font()
-            font.setPointSize(font.pointSize() + 1)
-            title_label.setFont(font)
-            title_label.setStyleSheet("""
-                background-color: palette(dark);
-                color: palette(bright-text);
-                border-bottom: 2px solid palette(mid);
-                padding: 4px;
-            """)
-            layout.addWidget(title_label, 0, COLUMN_LABEL, 1, 2)
-            row_offset = 1
-            self._section_title_widgets.append((title_label, keys))
-
-        # Option rows with alternating background
-        for idx, key in enumerate(keys):
-            row = idx + row_offset
-
-            row_widget = QWidget()
-            bg = "palette(alternate-base)" if idx % 2 == 0 else "palette(base)"
-            row_widget.setStyleSheet(f"background-color: {bg};")
-            row_widget.setProperty("_base_bg", bg)
-
-            row_layout = QHBoxLayout()
-            row_layout.setContentsMargins(
-                UIScaler.size(0.4),
-                UIScaler.size(0.2),
-                UIScaler.size(0.4),
-                UIScaler.size(0.2),
-            )
-            row_layout.setSpacing(UIScaler.size(0.4))
-
-            label = QLabel(format_option_name(key))
-            row_layout.addWidget(label)
-            row_layout.addWidget(self._create_editor_for_key(key))
-
-            row_widget.setLayout(row_layout)
-            layout.addWidget(row_widget, row, COLUMN_LABEL, 1, 2)
-
-            self._row_widgets[key] = row_widget
-            self._row_labels[key] = label
-
-        frame = QFrame()
-        frame.setObjectName("sectionFrame")
-        frame.setLayout(layout)
-        frame.setProperty("estimated_rows", len(keys) + (1 if title is not None else 0))
-        return frame
-
     def _build_sectioned_layout(self, keys: list[str]) -> QWidget:
         """Create section frames and arrange them for initial display."""
         sections = self.section_grouper.group_keys(keys)
+        self._sections = sections  # bewaar voor highlight
 
-        self._section_widgets = [
-            self._create_section_frame(title, sec_keys)
-            for title, sec_keys in sections
-        ]
+        for title, sec_keys in sections:
+            if all(k.startswith("column_index_") for k in sec_keys):
+                frame = self.builder._build_column_index_frame(title, sec_keys)
+                self._column_index_frames.append(frame)
+            elif title == "" and self._general_frame is None:
+                self._general_frame = self.builder.build_compact_frame(title, sec_keys)
+            else:
+                frame = self.builder._build_regular_section(title, sec_keys)
+                self._section_widgets.append(frame)
+
+        # Retrieve references from builder
+        self._row_widgets = self.builder.row_widgets
+        self._row_labels = self.builder.row_labels
+        self._section_title_widgets = self.builder.section_title_widgets
+        self._column_order_widgets = self.builder.column_order_widgets
 
         self._widest_section = max(
             (w.sizeHint().width() for w in self._section_widgets), default=1
         )
-        try:
-            avail_w = QApplication.primaryScreen().availableGeometry().width()
-        except AttributeError:
-            avail_w = 1920
-        num_columns = min(3, max(1, int(avail_w * 0.9) // max(self._widest_section, 1)))
-        return self._arrange_columns(num_columns)
+        return self._arrange_columns(1)
 
     def _arrange_columns(self, num_columns: int) -> QWidget:
         """Distribute section widgets into num_columns columns and return a container."""
         self._num_columns = num_columns
-        max_rows = 24
+        total_rows = sum(
+            (w.property("estimated_rows") or 10) for w in self._section_widgets
+        )
+        max_rows = max(24, -(-total_rows // num_columns))  # ceiling division
+
+        # Detach sections from old parent before re-parenting
+        for w in self._section_widgets:
+            w.setParent(None)
 
         columns: list[list[QFrame]] = [[] for _ in range(num_columns)]
         col_rows = [0] * num_columns
@@ -854,176 +304,263 @@ class UserConfig(BaseDialog):
         container.setLayout(main_layout)
         return container
 
-    def _cleanup(self):
-        """Stop timers and release preview resources"""
-        self.filter_timer.stop()
-        if self._preview is not None:
-            self._preview.cleanup()
+    # ------------------------------------------------------------------
+    # Search / filter methods (unchanged)
+    # ------------------------------------------------------------------
+    def _on_search_text_changed(self):
+        self.filter_timer.start(200)
 
-    def reject(self):
-        """Cancel / ESC"""
-        self._cleanup()
-        super().reject()
-
-    def closeEvent(self, event):
-        """Stop all timers before Qt tears down child widgets"""
-        self._cleanup()
-        super().closeEvent(event)
-
-    def resizeEvent(self, event):
-        """Reflow columns on window resize"""
-        super().resizeEvent(event)
-        if not self._section_widgets:
+    def _apply_filter(self):
+        text = self.search_edit.text().strip().lower()
+        if not text:
+            for key in self._row_widgets:
+                self._undim_row(key)
+            seen: set[int] = set()
+            for lw in self._column_order_widgets.values():
+                if id(lw) not in seen:
+                    seen.add(id(lw))
+                    lw.set_dimmed_keys(set())
+            for title_label, _ in self._section_title_widgets:
+                title_label.setStyleSheet("""
+                    background-color: palette(dark);
+                    color: palette(bright-text);
+                    border-bottom: 2px solid palette(mid);
+                    padding: 4px;
+                """)
             return
-        usable_w = event.size().width() - self.MARGIN * 2
-        new_num = min(3, max(1, usable_w // max(self._widest_section, 1)))
-        if new_num != self._num_columns:
-            self._scroll_box.setWidget(self._arrange_columns(new_num))
+
+        for key in self._row_widgets:
+            if text in key.lower():
+                self._undim_row(key)
+            else:
+                self._dim_row(key)
+
+        seen_lw: set[int] = set()
+        for lw in self._column_order_widgets.values():
+            if id(lw) not in seen_lw:
+                seen_lw.add(id(lw))
+                dimmed = set()
+                for k, w in self._column_order_widgets.items():
+                    if w is lw and text not in k.lower():
+                        dimmed.add(k)
+                lw.set_dimmed_keys(dimmed)
+
+        for title_label, keys in self._section_title_widgets:
+            all_dimmed = all(text not in k.lower() for k in keys)
+            if all_dimmed:
+                title_label.setStyleSheet("""
+                    background-color: palette(mid);
+                    color: palette(window);
+                    border-bottom: 2px solid palette(mid);
+                    padding: 4px;
+                """)
+            else:
+                title_label.setStyleSheet("""
+                    background-color: palette(dark);
+                    color: palette(bright-text);
+                    border-bottom: 2px solid palette(mid);
+                    padding: 4px;
+                """)
+
+    def _dim_row(self, key: str):
+        row_widget = self._row_widgets.get(key)
+        label = self._row_labels.get(key)
+        if row_widget is None:
+            return
+        row_widget.setStyleSheet("background-color: palette(window);")
+        if label is not None:
+            label.setStyleSheet("color: palette(mid);")
+
+    def _undim_row(self, key: str):
+        row_widget = self._row_widgets.get(key)
+        label = self._row_labels.get(key)
+        if row_widget is None:
+            return
+        bg = row_widget.property("_base_bg") or "palette(base)"
+        row_widget.setStyleSheet(f"background-color: {bg};")
+        if label is not None:
+            label.setStyleSheet("")
 
     def _focus_search(self):
-        """Focus and select all text in the search bar"""
         self.search_edit.setFocus()
         self.search_edit.selectAll()
 
+    # ------------------------------------------------------------------
+    # Sectie‑highlight
+    # ------------------------------------------------------------------
+    def highlight_section(self, column_key):
+        """Markeer alle opties van de sectie waartoe column_key behoort."""
+        # Zoek de sectie die deze column_key bevat
+        for title, keys in self._sections:
+            if column_key in keys:
+                # reset vorige highlight
+                self._reset_highlight()
+                # highlight de nieuwe sectie
+                for k in keys:
+                    row = self._row_widgets.get(k)
+                    if row:
+                        row.setStyleSheet("background-color: lightblue;")
+                        self._highlighted_keys.add(k)
+                break
+
+    def _reset_highlight(self):
+        """Zet alle gehighlighte rijen terug naar hun normale achtergrond."""
+        for k in self._highlighted_keys:
+            row = self._row_widgets.get(k)
+            if row:
+                bg = row.property("_base_bg") or "palette(base)"
+                row.setStyleSheet(f"background-color: {bg};")
+        self._highlighted_keys.clear()
+
+    # ------------------------------------------------------------------
+    # Herordenen van sectieframes
+    # ------------------------------------------------------------------
+    def reorder_sections(self):
+        """Sorteer de sectieframes op basis van minimale column_index van de bijbehorende keys."""
+        if not self._section_widgets:
+            return
+
+        # Bouw een lijst van (frame, min_column_index)
+        frame_index = []
+        for frame in self._section_widgets:
+            keys = frame.property("section_keys")
+            if not keys:
+                continue
+            min_idx = 999999
+            for k in keys:
+                if k.startswith("column_index_"):
+                    val = self._current_values.get(k, 999999)
+                    if isinstance(val, (int, float)):
+                        min_idx = min(min_idx, val)
+            frame_index.append((frame, min_idx))
+
+        # Sorteer op minimale index
+        frame_index.sort(key=lambda x: x[1])
+
+        # Werk de lijst van widgets bij
+        self._section_widgets = [f for f, _ in frame_index]
+
+        # Vernieuw de layout met het huidige aantal kolommen
+        new_container = self._arrange_columns(self._num_columns)
+        self._scroll_box.setWidget(new_container)
+
+    def on_column_order_changed(self):
+        """Wordt aangeroepen nadat de volgorde in de lijst is gewijzigd."""
+        self.reorder_sections()
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
     def applying(self):
-        """Save & apply"""
         self.save_setting(is_apply=True)
 
     def saving(self):
-        """Save & close"""
         self.save_setting(is_apply=False)
 
     def reset_setting(self):
-        """Reset setting to default values (and update cache)."""
         msg_text = (
             f"Reset all <b>{format_option_name(self.key_name)}</b> options to default?<br><br>"
             "Changes are only saved after clicking Apply or Save Button."
         )
         if self.confirm_operation(title="Reset Options", message=msg_text):
-            for key, editor in self.option_bool.items():
+            for key, editor in self.builder.editors.items():
                 default = editor.defaults
-                editor.setChecked(default)
-                self._current_values[key] = default
-            for key, editor in self.option_color.items():
-                default = editor.defaults
-                editor.setText(default)
-                self._current_values[key] = default
-            for key, editor in self.option_path.items():
-                default = editor.defaults
-                editor.setText(default)
-                self._current_values[key] = default
-            for key, editor in self.option_image.items():
-                default = editor.defaults
-                editor.setText(default)
-                self._current_values[key] = default
-            for key, editor in self.option_droplist.items():
-                default = str(editor.defaults)
-                editor.setCurrentText(default)
-                self._current_values[key] = default
-            for key, editor in self.option_string.items():
-                default = editor.defaults
-                editor.setText(default)
-                self._current_values[key] = default
-            for key, editor in self.option_integer.items():
-                default = str(editor.defaults)
-                editor.setText(default)
-                self._current_values[key] = int(default) if default.isdigit() else default
-            for key, editor in self.option_float.items():
-                default = str(editor.defaults)
-                editor.setText(default)
-                self._current_values[key] = float(default) if '.' in default else int(default)
+                if isinstance(editor, QCheckBox):
+                    editor.setChecked(default)
+                    self._current_values[key] = default
+                elif isinstance(editor, QLineEdit):
+                    editor.setText(str(default))
+                    self._current_values[key] = default
+                elif isinstance(editor, QComboBox):
+                    editor.setCurrentText(str(default))
+                    self._current_values[key] = default
+
             seen_column_lists: set = set()
-            for key, lw in self.option_column_order.items():
+            for key, lw in self._column_order_widgets.items():
                 if id(lw) not in seen_column_lists:
                     seen_column_lists.add(id(lw))
-                    all_keys = [k for k, w in self.option_column_order.items() if w is lw]
+                    all_keys = [k for k, w in self._column_order_widgets.items() if w is lw]
                     default_vals = {
                         k: self.default_setting[self.key_name][k] for k in all_keys
                     }
                     lw.reset_to_defaults(default_vals)
 
     def save_setting(self, is_apply: bool):
-        """Save setting from current cache, validate, and write to config."""
         user_setting = self.user_setting[self.key_name]
         error_found = False
 
-        # Validate and copy cached values into user_setting
-        for key, editor in self.option_bool.items():
-            user_setting[key] = self._current_values[key]
-
-        for key, editor in self.option_color.items():
+        for key in self.original_keys:
             value = self._current_values[key]
-            if is_hex_color(value):
+
+            if re.search(rxp.CFG_BOOL, key):
                 user_setting[key] = value
-            else:
-                self.value_error_message("color", key)
-                error_found = True
 
-        for key, editor in self.option_path.items():
-            value = self._current_values[key]
-            # Try convert to relative path again, in case user manually sets path
-            value = set_relative_path(value)
-            if set_user_data_path(value):
+            elif re.search(rxp.CFG_COLOR, key):
+                if is_hex_color(value):
+                    user_setting[key] = value
+                else:
+                    self.value_error_message("color", key)
+                    error_found = True
+
+            elif re.search(rxp.CFG_USER_PATH, key):
+                value = set_relative_path(value)
+                if set_user_data_path(value):
+                    user_setting[key] = value
+                    editor = self.builder.editors.get(key)
+                    if editor:
+                        editor.setText(value)
+                        self._current_values[key] = value
+                else:
+                    self.value_error_message("path", key)
+                    error_found = True
+
+            elif re.search(rxp.CFG_USER_IMAGE, key):
                 user_setting[key] = value
-                # Update editor and cache to the reformatted path
-                editor.setText(value)
-                self._current_values[key] = value
-            else:
-                self.value_error_message("path", key)
-                error_found = True
 
-        for key, editor in self.option_image.items():
-            user_setting[key] = self._current_values[key]
+            elif re.search(rxp.CFG_FONT_NAME, key) or re.search(rxp.CFG_HEATMAP, key) or \
+                 any(re.search(ref, key) for ref in rxp.CHOICE_UNITS) or \
+                 any(re.search(ref, key) for ref in rxp.CHOICE_COMMON):
+                user_setting[key] = value
 
-        for key, editor in self.option_droplist.items():
-            user_setting[key] = self._current_values[key]
+            elif re.search(rxp.CFG_CLOCK_FORMAT, key) or re.search(rxp.CFG_STRING, key):
+                if re.search(rxp.CFG_CLOCK_FORMAT, key) and not is_clock_format(value):
+                    self.value_error_message("clock format", key)
+                    error_found = True
+                else:
+                    user_setting[key] = value
 
-        for key, editor in self.option_string.items():
-            value = self._current_values[key]
-            if re.search(rxp.CFG_CLOCK_FORMAT, key) and not is_clock_format(value):
-                self.value_error_message("clock format", key)
-                error_found = True
-                continue
-            user_setting[key] = value
+            elif re.search(rxp.CFG_INTEGER, key):
+                str_val = str(value)
+                if is_string_number(str_val):
+                    user_setting[key] = int(str_val)
+                else:
+                    self.value_error_message("number", key)
+                    error_found = True
 
-        for key, editor in self.option_integer.items():
-            value = self._current_values[key]
-            # Ensure it's a string for validation, then convert back
-            str_val = str(value)
-            if is_string_number(str_val):
-                user_setting[key] = int(str_val)
-            else:
-                self.value_error_message("number", key)
-                error_found = True
+            else:  # float fallback
+                str_val = str(value)
+                if is_string_number(str_val):
+                    num_val = float(str_val)
+                    if num_val % 1 == 0:
+                        num_val = int(num_val)
+                    user_setting[key] = num_val
+                else:
+                    self.value_error_message("number", key)
+                    error_found = True
 
-        for key, editor in self.option_float.items():
-            value = self._current_values[key]
-            str_val = str(value)
-            if is_string_number(str_val):
-                num_val = float(str_val)
-                if num_val % 1 == 0:  # remove unnecessary decimal points
-                    num_val = int(num_val)
-                user_setting[key] = num_val
-            else:
-                self.value_error_message("number", key)
-                error_found = True
+        for key in self.original_keys:
+            if key.startswith("column_index_"):
+                user_setting[key] = self._current_values[key]
 
-        for key in self.option_column_order:
-            user_setting[key] = self._current_values[key]
-
-        # Abort saving if error found
         if error_found:
             return
 
-        # Save global settings
         if self.cfg_type == ConfigType.CONFIG:
             cfg.update_path()
             cfg.save(0, cfg_type=ConfigType.CONFIG)
-        # Save user preset settings
         else:
             cfg.save(0)
 
-        # Wait saving finish
         while cfg.is_saving:
             time.sleep(0.01)
 
@@ -1032,41 +569,33 @@ class UserConfig(BaseDialog):
             self.accept()
 
     def value_error_message(self, value_type: str, option_name: str):
-        """Value error message"""
         msg_text = (
             f"Invalid {value_type} for <b>{format_option_name(option_name)}</b> option."
             "<br><br>Changes are not saved."
         )
         QMessageBox.warning(self, "Error", msg_text)
 
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+    def _cleanup(self):
+        self.filter_timer.stop()
+        if self._preview is not None:
+            self._preview.cleanup()
 
-def set_preset_name(cfg_type: str):
-    """Set preset name"""
-    if cfg_type == ConfigType.CONFIG:
-        return f"{cfg.filename.config} (global)"
-    return cfg.filename.setting
+    def reject(self):
+        self._cleanup()
+        super().reject()
 
+    def closeEvent(self, event):
+        self._cleanup()
+        super().closeEvent(event)
 
-def add_context_menu(parent: QWidget):
-    """Add context menu"""
-    parent.setContextMenuPolicy(Qt.CustomContextMenu)
-    parent.customContextMenuRequested.connect(
-        lambda position, parent=parent: context_menu_reset_option(position, parent)
-    )
-
-
-def context_menu_reset_option(position: QPoint, parent: QWidget):
-    """Context menu reset option"""
-    menu = QMenu()  # no parent for temp menu
-    option_reset = menu.addAction("Reset to Default")
-    action = menu.exec_(parent.mapToGlobal(position))
-    if action == option_reset:
-        if isinstance(parent, QCheckBox):
-            parent.setChecked(parent.defaults)
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        if not self._section_widgets:
             return
-        if isinstance(parent, QLineEdit):
-            parent.setText(str(parent.defaults))
-            return
-        if isinstance(parent, QComboBox):
-            parent.setCurrentText(str(parent.defaults))
-            return
+        usable_w = self._scroll_box.viewport().width()
+        new_num = min(5, max(1, usable_w // max(self._widest_section, 1)))
+        if new_num != self._num_columns:
+            self._scroll_box.setWidget(self._arrange_columns(new_num))

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -43,7 +43,6 @@ from PySide2.QtWidgets import (
     QMessageBox,
     QScrollArea,
     QSpinBox,
-    QSplitter,
     QVBoxLayout,
     QWidget,
 )
@@ -372,19 +371,13 @@ class UserConfig(BaseDialog):
         else:
             self._preview = None
 
-        # Set main layout
+        # Set main layout: Preview (top) → Search → Editor → Buttons
         layout_main = QVBoxLayout()
         layout_button = QHBoxLayout()
-        layout_main.addLayout(search_layout)
         if self._preview is not None and self._preview.available:
-            splitter = QSplitter(Qt.Horizontal)
-            splitter.addWidget(scroll_box)
-            splitter.addWidget(self._preview)
-            splitter.setStretchFactor(0, 2)
-            splitter.setStretchFactor(1, 1)
-            layout_main.addWidget(splitter)
-        else:
-            layout_main.addWidget(scroll_box)
+            layout_main.addWidget(self._preview)
+        layout_main.addLayout(search_layout)
+        layout_main.addWidget(scroll_box, 1)
         layout_button.addWidget(button_reset)
         layout_button.addStretch(1)
         layout_button.addWidget(button_apply)

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -33,6 +33,7 @@ from PySide2.QtWidgets import (
     QCheckBox,
     QComboBox,
     QDialogButtonBox,
+    QFrame,
     QGridLayout,
     QHBoxLayout,
     QLabel,
@@ -72,6 +73,89 @@ def get_font_list() -> list[str]:
     return QFontDatabase().families()
 
 
+class SectionGrouper:
+    """Groups configuration keys based on JSON order and word overlap.
+
+    Consecutive show_* keys that share enough common words (or one is a
+    substring of the other) are merged into one section, keeping the title
+    of the first show_* key.  All non-show keys are appended to the current
+    section.  Fixed groups (column_index_*) are collected separately.
+    """
+
+    def __init__(self, min_match: int = 2):
+        self.min_match = min_match
+
+    @staticmethod
+    def _word_set(phrase: str) -> set[str]:
+        """Split an underscore-delimited name into a set of words."""
+        return set(phrase.split("_"))
+
+    def _similar(self, topic1: str, topic2: str) -> bool:
+        """Check whether two topics (without 'show_') belong together."""
+        # Direct match if one is a substring of the other
+        if topic1 in topic2 or topic2 in topic1:
+            return True
+        words1 = self._word_set(topic1)
+        words2 = self._word_set(topic2)
+        return len(words1 & words2) >= self.min_match
+
+    def group_keys(self, keys: list[str]) -> list[tuple[str | None, list[str]]]:
+        """Group keys into labelled sections.
+
+        Returns a list of (title, key_list) tuples.
+        """
+        # 1. Separate fixed groups (e.g. column_index_*)
+        fixed_groups: dict[str, list[str]] = {}
+        remaining: list[str] = []
+        for key in keys:
+            if key.startswith("column_index_"):
+                fixed_groups.setdefault("Column Index", []).append(key)
+            else:
+                remaining.append(key)
+
+        # 2. Iterate remaining keys and build sections
+        sections: list[tuple[str | None, list[str]]] = []
+        current_title: str | None = None
+        current_keys: list[str] = []
+        last_show: str | None = None
+
+        for key in remaining:
+            if key.startswith("show_"):
+                topic = key[5:]  # strip 'show_' prefix
+                if last_show is None:
+                    current_title = topic
+                    current_keys = [key]
+                    last_show = topic
+                elif self._similar(last_show, topic):
+                    current_keys.append(key)
+                    last_show = topic
+                else:
+                    sections.append((current_title, current_keys))
+                    current_title = topic
+                    current_keys = [key]
+                    last_show = topic
+            elif current_title is not None:
+                current_keys.append(key)
+
+        # Add last open section
+        if current_keys:
+            sections.append((current_title, current_keys))
+
+        # 3. Collect keys that appeared before the first show_* key
+        all_assigned: set[str] = set()
+        for _, key_list in sections:
+            all_assigned.update(key_list)
+        unassigned = [k for k in remaining if k not in all_assigned]
+        if unassigned:
+            sections.insert(0, ("", unassigned))
+
+        # 4. Append fixed groups
+        for title, fkeys in fixed_groups.items():
+            sections.append((title, fkeys))
+
+        return sections
+
+
 @singleton_dialog(ConfigType.CONFIG)
 class FontConfig(BaseDialog):
     """Config global font setting"""
@@ -90,7 +174,7 @@ class FontConfig(BaseDialog):
         self.edit_fontname.setFixedWidth(UIScaler.size(9))
 
         self.edit_fontsize = QSpinBox(self)
-        self.edit_fontsize.setRange(-999,999)
+        self.edit_fontsize.setRange(-999, 999)
         self.edit_fontsize.setFixedWidth(UIScaler.size(9))
 
         self.edit_fontweight = QComboBox(self)
@@ -103,7 +187,7 @@ class FontConfig(BaseDialog):
         self.edit_autooffset.setFixedWidth(UIScaler.size(9))
 
         self.edit_fontoffset = QSpinBox(self)
-        self.edit_fontoffset.setRange(-999,999)
+        self.edit_fontoffset.setRange(-999, 999)
         self.edit_fontoffset.setFixedWidth(UIScaler.size(9))
 
         layout_option = QGridLayout()
@@ -187,8 +271,8 @@ class FontConfig(BaseDialog):
         # Reset after applied
         self.edit_fontsize.setValue(0)
         self.edit_fontoffset.setValue(0)
-        # Wait saving finish
         cfg.save(0)
+        # Wait saving finish
         while cfg.is_saving:
             time.sleep(0.01)
         self.reloading()
@@ -196,11 +280,19 @@ class FontConfig(BaseDialog):
 
 @singleton_dialog(ConfigType.CONFIG)
 class UserConfig(BaseDialog):
-    """User configuration"""
+    """User configuration dialog with sectioned layout."""
 
     def __init__(
-        self, parent, key_name: str, cfg_type: str, user_setting: dict,
-        default_setting: dict, reload_func: Callable, option_width: int = 9):
+        self,
+        parent,
+        key_name: str,
+        cfg_type: str,
+        user_setting: dict,
+        default_setting: dict,
+        reload_func: Callable,
+        option_width: int = 9,
+        section_grouper: SectionGrouper | None = None,
+    ):
         """
         Args:
             key_name: config key name.
@@ -209,6 +301,8 @@ class UserConfig(BaseDialog):
             default_setting: default setting dictionary, ex. cfg.default.setting.
             reload_func: config reload (callback) function.
             option_width: option column width in pixels.
+            section_grouper: grouper instance that determines the section layout.
+                             Defaults to SectionGrouper() if not provided.
         """
         super().__init__(parent)
         self.set_config_title(format_option_name(key_name), set_preset_name(cfg_type))
@@ -219,13 +313,13 @@ class UserConfig(BaseDialog):
         self.user_setting = user_setting
         self.default_setting = default_setting
         self.option_width = UIScaler.size(option_width)
+        self.section_grouper = section_grouper or SectionGrouper()
 
         # Option dict (key: option editor)
         self.option_bool: dict = {}
         self.option_color: dict = {}
         self.option_path: dict = {}
         self.option_image: dict = {}
-        #self.option_fontname: dict = {}
         self.option_droplist: dict = {}
         self.option_string: dict = {}
         self.option_integer: dict = {}
@@ -243,11 +337,7 @@ class UserConfig(BaseDialog):
         button_save.rejected.connect(self.reject)
 
         # Create options
-        layout_option = QGridLayout()
-        layout_option.setAlignment(Qt.AlignTop)
-        self.create_options(layout_option)
-        option_box = QWidget(self)
-        option_box.setLayout(layout_option)
+        option_box = self._build_sectioned_layout()
 
         # Create scroll box
         scroll_box = QScrollArea(self)
@@ -257,7 +347,6 @@ class UserConfig(BaseDialog):
         # Set layout
         layout_main = QVBoxLayout()
         layout_button = QHBoxLayout()
-
         layout_main.addWidget(scroll_box)
         layout_button.addWidget(button_reset)
         layout_button.addStretch(1)
@@ -266,7 +355,256 @@ class UserConfig(BaseDialog):
         layout_main.addLayout(layout_button)
         layout_main.setContentsMargins(self.MARGIN, self.MARGIN, self.MARGIN, self.MARGIN)
         self.setLayout(layout_main)
+
+        # Window sizing
         self.setMinimumWidth(self.sizeHint().width() + UIScaler.size(2))
+        hint = option_box.sizeHint()
+        scroll_box.setMinimumWidth(hint.width() + UIScaler.size(4))
+        self.adjustSize()
+        try:
+            avail_h = self.screen().availableGeometry().height()
+        except AttributeError:
+            avail_h = 900
+        max_h = int(avail_h * 0.9)
+        if self.height() > max_h:
+            self.resize(self.width(), max_h)
+
+    def _create_editor_for_key(self, key: str) -> QWidget:
+        """Create and register an editor widget for the given key."""
+        user_val = self.user_setting[self.key_name][key]
+        default_val = self.default_setting[self.key_name][key]
+
+        # Bool
+        if re.search(rxp.CFG_BOOL, key):
+            editor = QCheckBox(self)
+            editor.setFixedWidth(self.option_width)
+            editor.setChecked(user_val)
+            editor.defaults = default_val
+            add_context_menu(editor)
+            self.option_bool[key] = editor
+            return editor
+
+        # Color string
+        if re.search(rxp.CFG_COLOR, key):
+            editor = DoubleClickEdit(self, mode="color", init=user_val)
+            editor.setFixedWidth(self.option_width)
+            editor.setMaxLength(9)
+            editor.setValidator(QVAL_COLOR)
+            editor.textChanged.connect(editor.preview_color)
+            editor.setText(user_val)
+            editor.defaults = default_val
+            add_context_menu(editor)
+            self.option_color[key] = editor
+            return editor
+
+        # User path string
+        if re.search(rxp.CFG_USER_PATH, key):
+            editor = DoubleClickEdit(self, mode="path", init=user_val)
+            editor.setFixedWidth(self.option_width)
+            editor.setText(user_val)
+            editor.defaults = default_val
+            add_context_menu(editor)
+            self.option_path[key] = editor
+            return editor
+
+        # User image file path string
+        if re.search(rxp.CFG_USER_IMAGE, key):
+            editor = DoubleClickEdit(self, mode="image", init=user_val)
+            editor.setFixedWidth(self.option_width)
+            editor.setText(user_val)
+            editor.defaults = default_val
+            add_context_menu(editor)
+            self.option_image[key] = editor
+            return editor
+
+        # Font name string
+        if re.search(rxp.CFG_FONT_NAME, key):
+            editor = QComboBox(self)
+            editor.setFixedWidth(self.option_width)
+            editor.addItems(get_font_list())
+            editor.setCurrentText(str(user_val))
+            editor.defaults = default_val
+            add_context_menu(editor)
+            self.option_droplist[key] = editor
+            return editor
+
+        # Heatmap string
+        if re.search(rxp.CFG_HEATMAP, key):
+            editor = QComboBox(self)
+            editor.setFixedWidth(self.option_width)
+            editor.addItems(cfg.user.heatmap.keys())
+            editor.setCurrentText(str(user_val))
+            editor.defaults = default_val
+            add_context_menu(editor)
+            self.option_droplist[key] = editor
+            return editor
+
+        # Units choice list string
+        for ref_key, choice_list in rxp.CHOICE_UNITS.items():
+            if re.search(ref_key, key):
+                editor = QComboBox(self)
+                editor.setFixedWidth(self.option_width)
+                editor.addItems(choice_list)
+                editor.setCurrentText(str(user_val))
+                editor.defaults = default_val
+                add_context_menu(editor)
+                self.option_droplist[key] = editor
+                return editor
+        # Common choice list string
+        for ref_key, choice_list in rxp.CHOICE_COMMON.items():
+            if re.search(ref_key, key):
+                editor = QComboBox(self)
+                editor.setFixedWidth(self.option_width)
+                editor.addItems(choice_list)
+                editor.setCurrentText(str(user_val))
+                editor.defaults = default_val
+                add_context_menu(editor)
+                self.option_droplist[key] = editor
+                return editor
+
+        # Clock format string
+        if re.search(rxp.CFG_CLOCK_FORMAT, key) or re.search(rxp.CFG_STRING, key):
+            editor = QLineEdit(self)
+            editor.setFixedWidth(self.option_width)
+            editor.setText(user_val)
+            editor.defaults = default_val
+            add_context_menu(editor)
+            self.option_string[key] = editor
+            return editor
+
+        # Integer
+        if re.search(rxp.CFG_INTEGER, key):
+            editor = QLineEdit(self)
+            editor.setFixedWidth(self.option_width)
+            editor.setValidator(QVAL_INTEGER)
+            editor.setText(str(user_val))
+            editor.defaults = default_val
+            add_context_menu(editor)
+            self.option_integer[key] = editor
+            return editor
+
+        # Float or int (fallback)
+        editor = QLineEdit(self)
+        editor.setFixedWidth(self.option_width)
+        editor.setValidator(QVAL_FLOAT)
+        editor.setText(str(user_val))
+        editor.defaults = default_val
+        add_context_menu(editor)
+        self.option_float[key] = editor
+        return editor
+
+    def _create_section_frame(self, title: str | None, keys: list) -> QFrame:
+        """Create a frame containing one section with title bar and alternating rows."""
+        layout = QGridLayout()
+        layout.setAlignment(Qt.AlignTop)
+        layout.setSpacing(0)
+        layout.setColumnStretch(COLUMN_LABEL, 0)
+        layout.setColumnStretch(COLUMN_OPTION, 1)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        row_offset = 0
+        if title is not None:
+            # Title bar
+            header_text = (
+                format_option_name(self.key_name)
+                if title == ""
+                else format_option_name(title)
+            )
+            title_label = QLabel(f"<b>{header_text}</b>")
+            font = title_label.font()
+            font.setPointSize(font.pointSize() + 1)
+            title_label.setFont(font)
+            title_label.setStyleSheet("""
+                background-color: palette(dark);
+                color: palette(bright-text);
+                border-bottom: 2px solid palette(mid);
+                padding: 4px;
+            """)
+            layout.addWidget(title_label, 0, COLUMN_LABEL, 1, 2)
+            row_offset = 1
+
+        # Option rows with alternating background
+        for idx, key in enumerate(keys):
+            row = idx + row_offset
+
+            row_widget = QWidget()
+            if idx % 2 == 0:
+                row_widget.setStyleSheet("background-color: palette(alternate-base);")
+            else:
+                row_widget.setStyleSheet("background-color: palette(base);")
+
+            row_layout = QHBoxLayout()
+            row_layout.setContentsMargins(
+                UIScaler.size(0.4),
+                UIScaler.size(0.2),
+                UIScaler.size(0.4),
+                UIScaler.size(0.2),
+            )
+            row_layout.setSpacing(UIScaler.size(0.4))
+
+            row_layout.addWidget(QLabel(format_option_name(key)))
+            row_layout.addWidget(self._create_editor_for_key(key))
+
+            row_widget.setLayout(row_layout)
+            layout.addWidget(row_widget, row, COLUMN_LABEL, 1, 2)
+
+        frame = QFrame()
+        frame.setObjectName("sectionFrame")
+        frame.setLayout(layout)
+        frame.setProperty("estimated_rows", len(keys) + (1 if title is not None else 0))
+        return frame
+
+    def _build_sectioned_layout(self) -> QWidget:
+        """Build the complete layout with sections distributed across columns."""
+        keys = list(self.user_setting[self.key_name])
+        sections = self.section_grouper.group_keys(keys)
+
+        section_widgets = [
+            self._create_section_frame(title, sec_keys)
+            for title, sec_keys in sections
+        ]
+
+        # Distribute sections across columns, max 24 rows per column
+        num_columns = 3
+        max_rows = 24
+
+        columns: list[list[QFrame]] = [[] for _ in range(num_columns)]
+        col_rows = [0] * num_columns
+
+        for widget in section_widgets:
+            est = widget.property("estimated_rows") or 10
+            # Place in the first column with enough room
+            for col in range(num_columns):
+                if col_rows[col] + est <= max_rows:
+                    columns[col].append(widget)
+                    col_rows[col] += est
+                    break
+            else:
+                # All columns full: place in least-loaded column
+                min_col = min(range(num_columns), key=lambda i: col_rows[i])
+                columns[min_col].append(widget)
+                col_rows[min_col] += est
+
+        # Build horizontal layout
+        main_layout = QHBoxLayout()
+        main_layout.setAlignment(Qt.AlignTop)
+        main_layout.setSpacing(UIScaler.size(2))
+
+        for col_widgets in columns:
+            if not col_widgets:
+                continue
+            col_layout = QVBoxLayout()
+            col_layout.setAlignment(Qt.AlignTop)
+            col_layout.setSpacing(UIScaler.size(1))
+            for w in col_widgets:
+                col_layout.addWidget(w)
+            col_container = QWidget()
+            col_container.setLayout(col_layout)
+            main_layout.addWidget(col_container, alignment=Qt.AlignTop)
+
+        container = QWidget()
+        container.setLayout(main_layout)
+        return container
 
     def applying(self):
         """Save & apply"""
@@ -285,28 +623,18 @@ class UserConfig(BaseDialog):
         if self.confirm_operation(title="Reset Options", message=msg_text):
             for editor in self.option_bool.values():
                 editor.setChecked(editor.defaults)
-
             for editor in self.option_color.values():
                 editor.setText(editor.defaults)
-
             for editor in self.option_path.values():
                 editor.setText(editor.defaults)
-
             for editor in self.option_image.values():
                 editor.setText(editor.defaults)
-
-            #for editor in self.option_fontname.values():
-            #    editor.setCurrentFont(editor.defaults)
-
             for editor in self.option_droplist.values():
                 editor.setCurrentText(str(editor.defaults))
-
             for editor in self.option_string.values():
                 editor.setText(editor.defaults)
-
             for editor in self.option_integer.values():
                 editor.setText(str(editor.defaults))
-
             for editor in self.option_float.values():
                 editor.setText(str(editor.defaults))
 
@@ -314,6 +642,7 @@ class UserConfig(BaseDialog):
         """Save setting"""
         user_setting = self.user_setting[self.key_name]
         error_found = False
+
         for key, editor in self.option_bool.items():
             user_setting[key] = editor.isChecked()
 
@@ -337,9 +666,6 @@ class UserConfig(BaseDialog):
 
         for key, editor in self.option_image.items():
             user_setting[key] = editor.text()
-
-        #for key, editor in self.option_fontname.items():
-        #    user_setting[key] = editor.currentFont().family()
 
         for key, editor in self.option_droplist.items():
             user_setting[key] = editor.currentText()
@@ -374,6 +700,7 @@ class UserConfig(BaseDialog):
         # Abort saving if error found
         if error_found:
             return
+
         # Save global settings
         if self.cfg_type == ConfigType.CONFIG:
             cfg.update_path()
@@ -381,12 +708,12 @@ class UserConfig(BaseDialog):
         # Save user preset settings
         else:
             cfg.save(0)
+
         # Wait saving finish
         while cfg.is_saving:
             time.sleep(0.01)
-        # Reload
+
         self.reloading()
-        # Close
         if not is_apply:
             self.accept()
 
@@ -397,194 +724,6 @@ class UserConfig(BaseDialog):
             "<br><br>Changes are not saved."
         )
         QMessageBox.warning(self, "Error", msg_text)
-
-    def create_options(self, layout):
-        """Create options"""
-        for idx, key in enumerate(self.user_setting[self.key_name]):
-            self.__add_option_label(idx, key, layout)
-            # Bool
-            if re.search(rxp.CFG_BOOL, key):
-                self.__add_option_bool(idx, key, layout)
-                continue
-            # Units choice list string
-            if self.__choice_match(rxp.CHOICE_UNITS, idx, key, layout):
-                continue
-            # Common choice list string
-            if self.__choice_match(rxp.CHOICE_COMMON, idx, key, layout):
-                continue
-            # Color string
-            if re.search(rxp.CFG_COLOR, key):
-                self.__add_option_color(idx, key, layout)
-                continue
-            # User path string
-            if re.search(rxp.CFG_USER_PATH, key):
-                self.__add_option_path(idx, key, layout)
-                continue
-            # User image file path string
-            if re.search(rxp.CFG_USER_IMAGE, key):
-                self.__add_option_image(idx, key, layout)
-                continue
-            # Font name string
-            if re.search(rxp.CFG_FONT_NAME, key):
-                self.__add_option_combolist(idx, key, layout, get_font_list())
-                continue
-            # Heatmap string
-            if re.search(rxp.CFG_HEATMAP, key):
-                self.__add_option_combolist(idx, key, layout, cfg.user.heatmap.keys())
-                continue
-            # Clock format string
-            if re.search(rxp.CFG_CLOCK_FORMAT, key):
-                self.__add_option_string(idx, key, layout)
-                continue
-            # String
-            if re.search(rxp.CFG_STRING, key):
-                self.__add_option_string(idx, key, layout)
-                continue
-            # Int
-            if re.search(rxp.CFG_INTEGER, key):
-                self.__add_option_integer(idx, key, layout)
-                continue
-            # Float or int
-            self.__add_option_float(idx, key, layout)
-
-    def __choice_match(self, choice_dict, idx, key, layout):
-        """Choice match"""
-        for ref_key, choice_list in choice_dict.items():
-            if re.search(ref_key, key):
-                self.__add_option_combolist(
-                    idx, key, layout, choice_list)
-                return True
-        return False
-
-    def __add_option_label(self, idx, key, layout):
-        """Option label"""
-        label = QLabel(format_option_name(key))
-        layout.addWidget(label, idx, COLUMN_LABEL)
-
-    def __add_option_bool(self, idx, key, layout):
-        """Bool"""
-        editor = QCheckBox(self)
-        editor.setFixedWidth(self.option_width)
-        editor.setChecked(self.user_setting[self.key_name][key])
-        # Context menu
-        editor.defaults = self.default_setting[self.key_name][key]
-        add_context_menu(editor)
-        # Add layout
-        layout.addWidget(editor, idx, COLUMN_OPTION)
-        self.option_bool[key] = editor
-
-    def __add_option_color(self, idx, key, layout):
-        """Color string"""
-        editor = DoubleClickEdit(
-            self, mode="color", init=self.user_setting[self.key_name][key])
-        editor.setFixedWidth(self.option_width)
-        editor.setMaxLength(9)
-        editor.setValidator(QVAL_COLOR)
-        editor.textChanged.connect(editor.preview_color)
-        # Load selected option
-        editor.setText(self.user_setting[self.key_name][key])
-        # Context menu
-        editor.defaults = self.default_setting[self.key_name][key]
-        add_context_menu(editor)
-        # Add layout
-        layout.addWidget(editor, idx, COLUMN_OPTION)
-        self.option_color[key] = editor
-
-    def __add_option_path(self, idx, key, layout):
-        """Path string"""
-        editor = DoubleClickEdit(
-            self, mode="path", init=self.user_setting[self.key_name][key])
-        editor.setFixedWidth(self.option_width)
-        # Load selected option
-        editor.setText(self.user_setting[self.key_name][key])
-        # Context menu
-        editor.defaults = self.default_setting[self.key_name][key]
-        add_context_menu(editor)
-        # Add layout
-        layout.addWidget(editor, idx, COLUMN_OPTION)
-        self.option_path[key] = editor
-
-    def __add_option_image(self, idx, key, layout):
-        """Image file path string"""
-        editor = DoubleClickEdit(
-            self, mode="image", init=self.user_setting[self.key_name][key])
-        editor.setFixedWidth(self.option_width)
-        # Load selected option
-        editor.setText(self.user_setting[self.key_name][key])
-        # Context menu
-        editor.defaults = self.default_setting[self.key_name][key]
-        add_context_menu(editor)
-        # Add layout
-        layout.addWidget(editor, idx, COLUMN_OPTION)
-        self.option_image[key] = editor
-
-    #def __add_option_fontname(self, idx, key, layout):
-    #    """Font name string"""
-    #    editor = QFontComboBox(self)
-    #    editor.setFixedWidth(self.option_width)
-    #    # Load selected option
-    #    editor.setCurrentFont(self.user_setting[self.key_name][key])
-    #    # Context menu
-    #    editor.defaults = self.default_setting[self.key_name][key]
-    #    add_context_menu(editor)
-    #    # Add layout
-    #    layout.addWidget(editor, idx, COLUMN_OPTION)
-    #    self.option_fontname[key] = editor
-
-    def __add_option_combolist(self, idx, key, layout, item_list):
-        """Combo droplist string"""
-        editor = QComboBox(self)
-        editor.setFixedWidth(self.option_width)
-        editor.addItems(item_list)
-        # Load selected option
-        editor.setCurrentText(str(self.user_setting[self.key_name][key]))
-        # Context menu
-        editor.defaults = self.default_setting[self.key_name][key]
-        add_context_menu(editor)
-        # Add layout
-        layout.addWidget(editor, idx, COLUMN_OPTION)
-        self.option_droplist[key] = editor
-
-    def __add_option_string(self, idx, key, layout):
-        """String"""
-        editor = QLineEdit(self)
-        editor.setFixedWidth(self.option_width)
-        # Load selected option
-        editor.setText(self.user_setting[self.key_name][key])
-        # Context menu
-        editor.defaults = self.default_setting[self.key_name][key]
-        add_context_menu(editor)
-        # Add layout
-        layout.addWidget(editor, idx, COLUMN_OPTION)
-        self.option_string[key] = editor
-
-    def __add_option_integer(self, idx, key, layout):
-        """Integer"""
-        editor = QLineEdit(self)
-        editor.setFixedWidth(self.option_width)
-        editor.setValidator(QVAL_INTEGER)
-        # Load selected option
-        editor.setText(str(self.user_setting[self.key_name][key]))
-        # Context menu
-        editor.defaults = self.default_setting[self.key_name][key]
-        add_context_menu(editor)
-        # Add layout
-        layout.addWidget(editor, idx, COLUMN_OPTION)
-        self.option_integer[key] = editor
-
-    def __add_option_float(self, idx, key, layout):
-        """Float"""
-        editor = QLineEdit(self)
-        editor.setFixedWidth(self.option_width)
-        editor.setValidator(QVAL_FLOAT)
-        # Load selected option
-        editor.setText(str(self.user_setting[self.key_name][key]))
-        # Context menu
-        editor.defaults = self.default_setting[self.key_name][key]
-        add_context_menu(editor)
-        # Add layout
-        layout.addWidget(editor, idx, COLUMN_OPTION)
-        self.option_float[key] = editor
 
 
 def set_preset_name(cfg_type: str):

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -46,6 +46,7 @@ from PySide2.QtWidgets import (
     QMessageBox,
     QScrollArea,
     QSpinBox,
+    QSplitter,
     QVBoxLayout,
     QWidget,
 )
@@ -56,6 +57,7 @@ from ..formatter import format_option_name
 from ..setting import cfg
 from ..userfile import set_relative_path, set_user_data_path
 from ..validator import is_clock_format, is_hex_color, is_string_number
+from .config_preview import WidgetPreview
 from ._common import (
     QVAL_COLOR,
     QVAL_FLOAT,
@@ -387,6 +389,7 @@ class UserConfig(BaseDialog):
         self.option_integer: dict = {}
         self.option_float: dict = {}
         self.option_column_order: dict = {}  # key -> ColumnIndexList widget
+        self._preview: WidgetPreview | None = None
 
         # Section widgets and current column count (used for dynamic reflow)
         self._section_widgets: list[QFrame] = []
@@ -427,11 +430,22 @@ class UserConfig(BaseDialog):
         scroll_box.setWidgetResizable(True)
         self._scroll_box = scroll_box
 
+        # Preview panel
+        self._preview = WidgetPreview(key_name, parent=self)
+
         # Set main layout
         layout_main = QVBoxLayout()
         layout_button = QHBoxLayout()
         layout_main.addLayout(search_layout)
-        layout_main.addWidget(scroll_box)
+        if self._preview.available:
+            splitter = QSplitter(Qt.Horizontal)
+            splitter.addWidget(scroll_box)
+            splitter.addWidget(self._preview)
+            splitter.setStretchFactor(0, 2)
+            splitter.setStretchFactor(1, 1)
+            layout_main.addWidget(splitter)
+        else:
+            layout_main.addWidget(scroll_box)
         layout_button.addWidget(button_reset)
         layout_button.addStretch(1)
         layout_button.addWidget(button_apply)
@@ -500,6 +514,8 @@ class UserConfig(BaseDialog):
     def _update_current_value(self, key, value):
         """Update value cache"""
         self._current_values[key] = value
+        if self._preview is not None:
+            self._preview.schedule_refresh(self._current_values)
 
     def _create_editor_for_key(self, key: str) -> QWidget:
         """Create editor widget for key"""

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -533,7 +533,7 @@ class UserConfig(BaseDialog):
             editor.setChecked(current_val)
             editor.defaults = default_val
             editor.stateChanged.connect(
-                lambda state, k=key: self._update_current_value(k, state == Qt.Checked)
+                lambda state, k=key: self._update_current_value(k, bool(state))
             )
             add_context_menu(editor)
             self.option_bool[key] = editor

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -317,6 +317,12 @@ class UserConfig(BaseDialog):
         self.option_column_order: dict = {}  # key -> ColumnIndexList widget
         self._preview: WidgetPreview | None = None
 
+        # Row tracking for search dimming
+        self._row_widgets: dict[str, QWidget] = {}   # key -> row container
+        self._row_labels: dict[str, QLabel] = {}      # key -> label widget
+        self._section_title_widgets: list[tuple[QLabel, list[str]]] = []  # (title_label, keys)
+        self._column_order_widgets: dict[str, DragDropOrderList] = {}  # key -> list widget
+
         # Section widgets and current column count (used for dynamic reflow)
         self._section_widgets: list[QFrame] = []
         self._num_columns = 0
@@ -407,42 +413,95 @@ class UserConfig(BaseDialog):
         self.filter_timer.start(200)  # milliseconds
 
     def _apply_filter(self):
-        """Rebuild layout with keys that match the current filter text."""
+        """Dim non-matching rows based on the current filter text."""
         text = self.search_edit.text().strip().lower()
         if not text:
-            filtered_keys = self.original_keys
-        else:
-            filtered_keys = [key for key in self.original_keys if text in key.lower()]
-        self.rebuild_filtered_layout(filtered_keys)
+            # Restore all rows
+            for key in self._row_widgets:
+                self._undim_row(key)
+            # Restore all drag-drop rows
+            seen: set[int] = set()
+            for lw in self._column_order_widgets.values():
+                if id(lw) not in seen:
+                    seen.add(id(lw))
+                    lw.set_dimmed_keys(set(), 1.0)
+            # Restore all section titles
+            for title_label, _ in self._section_title_widgets:
+                title_label.setStyleSheet("""
+                    background-color: palette(dark);
+                    color: palette(bright-text);
+                    border-bottom: 2px solid palette(mid);
+                    padding: 4px;
+                """)
+            return
 
-    def rebuild_filtered_layout(self, keys: list[str]):
-        """Rebuild the sectioned layout using only the given keys."""
-        # Clear old option dictionaries
-        self.option_bool.clear()
-        self.option_color.clear()
-        self.option_path.clear()
-        self.option_image.clear()
-        self.option_droplist.clear()
-        self.option_string.clear()
-        self.option_integer.clear()
-        self.option_float.clear()
-        self.option_column_order.clear()
+        opacity = self._calc_dim_opacity(len(text))
 
-        # Group the filtered keys and create new section frames
-        sections = self.section_grouper.group_keys(keys)
-        self._section_widgets = [
-            self._create_section_frame(title, sec_keys)
-            for title, sec_keys in sections
-        ]
+        # Dim/undim regular rows
+        for key in self._row_widgets:
+            if text in key.lower():
+                self._undim_row(key)
+            else:
+                self._dim_row(key, opacity)
 
-        # Recalculate widest section for column layout
-        self._widest_section = max(
-            (w.sizeHint().width() for w in self._section_widgets), default=1
+        # Dim/undim drag-drop rows
+        seen_lw: set[int] = set()
+        for lw in self._column_order_widgets.values():
+            if id(lw) not in seen_lw:
+                seen_lw.add(id(lw))
+                dimmed = set()
+                for k, w in self._column_order_widgets.items():
+                    if w is lw and text not in k.lower():
+                        dimmed.add(k)
+                lw.set_dimmed_keys(dimmed, opacity)
+
+        # Dim section titles when all their rows are dimmed
+        for title_label, keys in self._section_title_widgets:
+            all_dimmed = all(
+                text not in k.lower() for k in keys
+            )
+            if all_dimmed:
+                title_label.setStyleSheet(f"""
+                    background-color: rgba(128, 128, 128, {opacity});
+                    color: rgba(128, 128, 128, {opacity});
+                    border-bottom: 2px solid palette(mid);
+                    padding: 4px;
+                """)
+            else:
+                title_label.setStyleSheet("""
+                    background-color: palette(dark);
+                    color: palette(bright-text);
+                    border-bottom: 2px solid palette(mid);
+                    padding: 4px;
+                """)
+
+    @staticmethod
+    def _calc_dim_opacity(search_len: int) -> float:
+        """Return opacity for dimmed rows: 0.6 at 1 char, down to 0.2 at 5+ chars."""
+        return max(0.2, 0.7 - 0.1 * search_len)
+
+    def _dim_row(self, key: str, opacity: float):
+        """Apply dim styling to a row widget and its label."""
+        row_widget = self._row_widgets.get(key)
+        label = self._row_labels.get(key)
+        if row_widget is None:
+            return
+        row_widget.setStyleSheet(
+            f"background-color: rgba(128, 128, 128, {opacity});"
         )
+        if label is not None:
+            label.setStyleSheet(f"color: rgba(128, 128, 128, {opacity});")
 
-        # Rearrange columns using the current column count
-        new_container = self._arrange_columns(self._num_columns)
-        self._scroll_box.setWidget(new_container)
+    def _undim_row(self, key: str):
+        """Restore original styling to a row widget and its label."""
+        row_widget = self._row_widgets.get(key)
+        label = self._row_labels.get(key)
+        if row_widget is None:
+            return
+        bg = row_widget.property("_base_bg") or "palette(base)"
+        row_widget.setStyleSheet(f"background-color: {bg};")
+        if label is not None:
+            label.setStyleSheet("")
 
     def _update_current_value(self, key, value):
         """Update value cache"""
@@ -628,21 +687,22 @@ class UserConfig(BaseDialog):
         layout.setSpacing(0)
         layout.setContentsMargins(0, 0, 0, 0)
 
+        col_title_label = None
         if title is not None:
             header_text = (
                 format_option_name(self.key_name) if title == "" else "Display Order"
             )
-            title_label = QLabel(f"<b>{header_text}</b>")
-            font = title_label.font()
+            col_title_label = QLabel(f"<b>{header_text}</b>")
+            font = col_title_label.font()
             font.setPointSize(font.pointSize() + 1)
-            title_label.setFont(font)
-            title_label.setStyleSheet("""
+            col_title_label.setFont(font)
+            col_title_label.setStyleSheet("""
                 background-color: palette(dark);
                 color: palette(bright-text);
                 border-bottom: 2px solid palette(mid);
                 padding: 4px;
             """)
-            layout.addWidget(title_label)
+            layout.addWidget(col_title_label)
 
         sorted_keys = sorted(
             keys,
@@ -666,8 +726,12 @@ class UserConfig(BaseDialog):
         )
         for key in keys:
             self.option_column_order[key] = list_widget
+            self._column_order_widgets[key] = list_widget
 
         layout.addWidget(list_widget)
+
+        if col_title_label is not None:
+            self._section_title_widgets.append((col_title_label, keys))
 
         frame = QFrame()
         frame.setObjectName("sectionFrame")
@@ -706,16 +770,16 @@ class UserConfig(BaseDialog):
             """)
             layout.addWidget(title_label, 0, COLUMN_LABEL, 1, 2)
             row_offset = 1
+            self._section_title_widgets.append((title_label, keys))
 
         # Option rows with alternating background
         for idx, key in enumerate(keys):
             row = idx + row_offset
 
             row_widget = QWidget()
-            if idx % 2 == 0:
-                row_widget.setStyleSheet("background-color: palette(alternate-base);")
-            else:
-                row_widget.setStyleSheet("background-color: palette(base);")
+            bg = "palette(alternate-base)" if idx % 2 == 0 else "palette(base)"
+            row_widget.setStyleSheet(f"background-color: {bg};")
+            row_widget.setProperty("_base_bg", bg)
 
             row_layout = QHBoxLayout()
             row_layout.setContentsMargins(
@@ -726,11 +790,15 @@ class UserConfig(BaseDialog):
             )
             row_layout.setSpacing(UIScaler.size(0.4))
 
-            row_layout.addWidget(QLabel(format_option_name(key)))
+            label = QLabel(format_option_name(key))
+            row_layout.addWidget(label)
             row_layout.addWidget(self._create_editor_for_key(key))
 
             row_widget.setLayout(row_layout)
             layout.addWidget(row_widget, row, COLUMN_LABEL, 1, 2)
+
+            self._row_widgets[key] = row_widget
+            self._row_labels[key] = label
 
         frame = QFrame()
         frame.setObjectName("sectionFrame")

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -30,6 +30,7 @@ from typing import Callable
 from PySide2.QtCore import QPoint, Qt
 from PySide2.QtGui import QFontDatabase
 from PySide2.QtWidgets import (
+    QApplication,
     QCheckBox,
     QComboBox,
     QDialogButtonBox,
@@ -63,7 +64,6 @@ from ._common import (
 )
 
 COLUMN_LABEL = 0  # grid layout column index
-COLUMN_OPTION = 1
 
 
 def get_font_list() -> list[str]:
@@ -325,6 +325,11 @@ class UserConfig(BaseDialog):
         self.option_integer: dict = {}
         self.option_float: dict = {}
 
+        # Section widgets and current column count (used for dynamic reflow)
+        self._section_widgets: list[QFrame] = []
+        self._num_columns = 0
+        self._widest_section = 0
+
         # Button
         button_reset = QDialogButtonBox(QDialogButtonBox.Reset)
         button_reset.clicked.connect(self.reset_setting)
@@ -343,6 +348,7 @@ class UserConfig(BaseDialog):
         scroll_box = QScrollArea(self)
         scroll_box.setWidget(option_box)
         scroll_box.setWidgetResizable(True)
+        self._scroll_box = scroll_box  # keep reference for dynamic column reflow
 
         # Set layout
         layout_main = QVBoxLayout()
@@ -358,16 +364,18 @@ class UserConfig(BaseDialog):
 
         # Window sizing
         self.setMinimumWidth(self.sizeHint().width() + UIScaler.size(2))
-        hint = option_box.sizeHint()
-        scroll_box.setMinimumWidth(hint.width() + UIScaler.size(4))
         self.adjustSize()
         try:
-            avail_h = self.screen().availableGeometry().height()
+            avail = self.screen().availableGeometry()
+            max_w = int(avail.width() * 0.9)
+            max_h = int(avail.height() * 0.9)
         except AttributeError:
-            avail_h = 900
-        max_h = int(avail_h * 0.9)
-        if self.height() > max_h:
-            self.resize(self.width(), max_h)
+            max_w = 1600
+            max_h = 900
+        new_w = min(self.width(), max_w)
+        new_h = min(self.height(), max_h)
+        if new_w != self.width() or new_h != self.height():
+            self.resize(new_w, new_h)
 
     def _create_editor_for_key(self, key: str) -> QWidget:
         """Create and register an editor widget for the given key."""
@@ -498,8 +506,6 @@ class UserConfig(BaseDialog):
         layout = QGridLayout()
         layout.setAlignment(Qt.AlignTop)
         layout.setSpacing(0)
-        layout.setColumnStretch(COLUMN_LABEL, 0)
-        layout.setColumnStretch(COLUMN_OPTION, 1)
         layout.setContentsMargins(0, 0, 0, 0)
 
         row_offset = 0
@@ -555,23 +561,34 @@ class UserConfig(BaseDialog):
         return frame
 
     def _build_sectioned_layout(self) -> QWidget:
-        """Build the complete layout with sections distributed across columns."""
+        """Create section frames and arrange them for initial display."""
         keys = list(self.user_setting[self.key_name])
         sections = self.section_grouper.group_keys(keys)
 
-        section_widgets = [
+        self._section_widgets = [
             self._create_section_frame(title, sec_keys)
             for title, sec_keys in sections
         ]
 
-        # Distribute sections across columns, max 24 rows per column
-        num_columns = 3
+        self._widest_section = max(
+            (w.sizeHint().width() for w in self._section_widgets), default=1
+        )
+        try:
+            avail_w = QApplication.primaryScreen().availableGeometry().width()
+        except AttributeError:
+            avail_w = 1920
+        num_columns = min(3, max(1, int(avail_w * 0.9) // max(self._widest_section, 1)))
+        return self._arrange_columns(num_columns)
+
+    def _arrange_columns(self, num_columns: int) -> QWidget:
+        """Distribute section widgets into num_columns columns and return a container."""
+        self._num_columns = num_columns
         max_rows = 24
 
         columns: list[list[QFrame]] = [[] for _ in range(num_columns)]
         col_rows = [0] * num_columns
 
-        for widget in section_widgets:
+        for widget in self._section_widgets:
             est = widget.property("estimated_rows") or 10
             # Place in the first column with enough room
             for col in range(num_columns):
@@ -585,7 +602,6 @@ class UserConfig(BaseDialog):
                 columns[min_col].append(widget)
                 col_rows[min_col] += est
 
-        # Build horizontal layout
         main_layout = QHBoxLayout()
         main_layout.setAlignment(Qt.AlignTop)
         main_layout.setSpacing(UIScaler.size(2))
@@ -594,17 +610,27 @@ class UserConfig(BaseDialog):
             if not col_widgets:
                 continue
             col_layout = QVBoxLayout()
-            col_layout.setAlignment(Qt.AlignTop)
             col_layout.setSpacing(UIScaler.size(1))
             for w in col_widgets:
                 col_layout.addWidget(w)
+            col_layout.addStretch(1)
             col_container = QWidget()
             col_container.setLayout(col_layout)
-            main_layout.addWidget(col_container, alignment=Qt.AlignTop)
+            main_layout.addWidget(col_container, 1)
 
         container = QWidget()
         container.setLayout(main_layout)
         return container
+
+    def resizeEvent(self, event):
+        """Reflow columns when the window becomes wide or narrow enough."""
+        super().resizeEvent(event)
+        if not self._section_widgets:
+            return
+        usable_w = event.size().width() - self.MARGIN * 2
+        new_num = min(3, max(1, usable_w // max(self._widest_section, 1)))
+        if new_num != self._num_columns:
+            self._scroll_box.setWidget(self._arrange_columns(new_num))
 
     def applying(self):
         """Save & apply"""

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -45,6 +45,7 @@ from PySide2.QtWidgets import (
     QMenu,
     QMessageBox,
     QScrollArea,
+    QShortcut,
     QSpinBox,
     QSplitter,
     QVBoxLayout,
@@ -405,8 +406,12 @@ class UserConfig(BaseDialog):
         self.search_edit.textChanged.connect(self._on_search_text_changed)
         search_layout.addWidget(self.search_edit)
 
+        # Ctrl+F shortcut: fires regardless of which child widget has focus
+        shortcut_find = QShortcut(QKeySequence.Find, self)
+        shortcut_find.activated.connect(self._focus_search)
+
         # Debounce timer
-        self.filter_timer = QTimer()
+        self.filter_timer = QTimer(self)
         self.filter_timer.setSingleShot(True)
         self.filter_timer.timeout.connect(self._apply_filter)
 
@@ -833,6 +838,13 @@ class UserConfig(BaseDialog):
         container.setLayout(main_layout)
         return container
 
+    def closeEvent(self, event):
+        """Stop all timers before Qt tears down child widgets"""
+        self.filter_timer.stop()
+        if self._preview is not None:
+            self._preview.cleanup()
+        super().closeEvent(event)
+
     def resizeEvent(self, event):
         """Reflow columns on window resize"""
         super().resizeEvent(event)
@@ -843,14 +855,10 @@ class UserConfig(BaseDialog):
         if new_num != self._num_columns:
             self._scroll_box.setWidget(self._arrange_columns(new_num))
 
-    def keyPressEvent(self, event):
-        """Focus search bar on Ctrl+F"""
-        if event.matches(QKeySequence.Find):
-            self.search_edit.setFocus()
-            self.search_edit.selectAll()
-            event.accept()
-        else:
-            super().keyPressEvent(event)
+    def _focus_search(self):
+        """Focus and select all text in the search bar"""
+        self.search_edit.setFocus()
+        self.search_edit.selectAll()
 
     def applying(self):
         """Save & apply"""

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -434,14 +434,17 @@ class UserConfig(BaseDialog):
         scroll_box.setWidgetResizable(True)
         self._scroll_box = scroll_box
 
-        # Preview panel
-        self._preview = WidgetPreview(key_name, parent=self)
+        # Preview panel (only for widget configs)
+        if cfg_type == ConfigType.WIDGET:
+            self._preview = WidgetPreview(key_name, parent=self)
+        else:
+            self._preview = None
 
         # Set main layout
         layout_main = QVBoxLayout()
         layout_button = QHBoxLayout()
         layout_main.addLayout(search_layout)
-        if self._preview.available:
+        if self._preview is not None and self._preview.available:
             splitter = QSplitter(Qt.Horizontal)
             splitter.addWidget(scroll_box)
             splitter.addWidget(self._preview)

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -820,15 +820,18 @@ class UserConfig(BaseDialog):
                 columns[min_col].append(widget)
                 col_rows[min_col] += est
 
+        col_gap = UIScaler.size(1) if num_columns > 1 else 0
         main_layout = QHBoxLayout()
         main_layout.setAlignment(Qt.AlignTop)
-        main_layout.setSpacing(UIScaler.size(2))
+        main_layout.setSpacing(col_gap)
+        main_layout.setContentsMargins(0, 0, 0, 0)
 
         for col_widgets in columns:
             if not col_widgets:
                 continue
             col_layout = QVBoxLayout()
-            col_layout.setSpacing(UIScaler.size(1))
+            col_layout.setSpacing(0)
+            col_layout.setContentsMargins(0, 0, 0, 0)
             for w in col_widgets:
                 col_layout.addWidget(w)
             col_layout.addStretch(1)

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -424,7 +424,7 @@ class UserConfig(BaseDialog):
             for lw in self._column_order_widgets.values():
                 if id(lw) not in seen:
                     seen.add(id(lw))
-                    lw.set_dimmed_keys(set(), 1.0)
+                    lw.set_dimmed_keys(set())
             # Restore all section titles
             for title_label, _ in self._section_title_widgets:
                 title_label.setStyleSheet("""
@@ -435,14 +435,12 @@ class UserConfig(BaseDialog):
                 """)
             return
 
-        opacity = self._calc_dim_opacity(len(text))
-
         # Dim/undim regular rows
         for key in self._row_widgets:
             if text in key.lower():
                 self._undim_row(key)
             else:
-                self._dim_row(key, opacity)
+                self._dim_row(key)
 
         # Dim/undim drag-drop rows
         seen_lw: set[int] = set()
@@ -453,7 +451,7 @@ class UserConfig(BaseDialog):
                 for k, w in self._column_order_widgets.items():
                     if w is lw and text not in k.lower():
                         dimmed.add(k)
-                lw.set_dimmed_keys(dimmed, opacity)
+                lw.set_dimmed_keys(dimmed)
 
         # Dim section titles when all their rows are dimmed
         for title_label, keys in self._section_title_widgets:
@@ -461,9 +459,9 @@ class UserConfig(BaseDialog):
                 text not in k.lower() for k in keys
             )
             if all_dimmed:
-                title_label.setStyleSheet(f"""
-                    background-color: rgba(128, 128, 128, {opacity});
-                    color: rgba(128, 128, 128, {opacity});
+                title_label.setStyleSheet("""
+                    background-color: palette(mid);
+                    color: palette(window);
                     border-bottom: 2px solid palette(mid);
                     padding: 4px;
                 """)
@@ -475,22 +473,15 @@ class UserConfig(BaseDialog):
                     padding: 4px;
                 """)
 
-    @staticmethod
-    def _calc_dim_opacity(search_len: int) -> float:
-        """Return opacity for dimmed rows: 0.6 at 1 char, down to 0.2 at 5+ chars."""
-        return max(0.2, 0.7 - 0.1 * search_len)
-
-    def _dim_row(self, key: str, opacity: float):
+    def _dim_row(self, key: str):
         """Apply dim styling to a row widget and its label."""
         row_widget = self._row_widgets.get(key)
         label = self._row_labels.get(key)
         if row_widget is None:
             return
-        row_widget.setStyleSheet(
-            f"background-color: rgba(128, 128, 128, {opacity});"
-        )
+        row_widget.setStyleSheet("background-color: palette(window);")
         if label is not None:
-            label.setStyleSheet(f"color: rgba(128, 128, 128, {opacity});")
+            label.setStyleSheet("color: palette(mid);")
 
     def _undim_row(self, key: str):
         """Restore original styling to a row widget and its label."""

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -30,6 +30,7 @@ from typing import Callable
 from PySide2.QtCore import QPoint, Qt, QTimer
 from PySide2.QtGui import QFontDatabase, QKeySequence
 from PySide2.QtWidgets import (
+    QAbstractItemView,
     QApplication,
     QCheckBox,
     QComboBox,
@@ -39,6 +40,8 @@ from PySide2.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QListWidget,
+    QListWidgetItem,
     QMenu,
     QMessageBox,
     QScrollArea,
@@ -74,24 +77,18 @@ def get_font_list() -> list[str]:
 
 
 class SectionGrouper:
-    """Groups configuration keys based on JSON order and word overlap.
-
-    Consecutive show_* keys that share enough common words (or one is a
-    substring of the other) are merged into one section, keeping the title
-    of the first show_* key.  All non-show keys are appended to the current
-    section.  Fixed groups (column_index_*) are collected separately.
-    """
+    """Groups configuration keys into labelled sections by word overlap"""
 
     def __init__(self, min_match: int = 2):
         self.min_match = min_match
 
     @staticmethod
     def _word_set(phrase: str) -> set[str]:
-        """Split an underscore-delimited name into a set of words."""
+        """Split underscore-delimited name into word set"""
         return set(phrase.split("_"))
 
     def _similar(self, topic1: str, topic2: str) -> bool:
-        """Check whether two topics (without 'show_') belong together."""
+        """Check if two topics share enough words to belong in one section"""
         # Direct match if one is a substring of the other
         if topic1 in topic2 or topic2 in topic1:
             return True
@@ -100,11 +97,8 @@ class SectionGrouper:
         return len(words1 & words2) >= self.min_match
 
     def group_keys(self, keys: list[str]) -> list[tuple[str | None, list[str]]]:
-        """Group keys into labelled sections.
-
-        Returns a list of (title, key_list) tuples.
-        """
-        # 1. Separate fixed groups (e.g. column_index_*)
+        """Group keys into labelled sections, returns list of (title, key_list) tuples"""
+        # Separate column_index_* into its own group
         fixed_groups: dict[str, list[str]] = {}
         remaining: list[str] = []
         for key in keys:
@@ -113,7 +107,7 @@ class SectionGrouper:
             else:
                 remaining.append(key)
 
-        # 2. Iterate remaining keys and build sections
+        # Build sections from remaining keys
         sections: list[tuple[str | None, list[str]]] = []
         current_title: str | None = None
         current_keys: list[str] = []
@@ -141,7 +135,7 @@ class SectionGrouper:
         if current_keys:
             sections.append((current_title, current_keys))
 
-        # 3. Collect keys that appeared before the first show_* key
+        # Collect keys that appeared before the first show_* key
         all_assigned: set[str] = set()
         for _, key_list in sections:
             all_assigned.update(key_list)
@@ -149,11 +143,83 @@ class SectionGrouper:
         if unassigned:
             sections.insert(0, ("", unassigned))
 
-        # 4. Append fixed groups
+        # Append fixed groups
         for title, fkeys in fixed_groups.items():
             sections.append((title, fkeys))
 
         return sections
+
+
+class ColumnIndexList(QListWidget):
+    """Drag-and-drop list for setting display order of columns"""
+
+    def __init__(self, keys: list, current_values: dict, update_callback, parent=None):
+        super().__init__(parent)
+        self.setDragDropMode(QAbstractItemView.InternalMove)
+        self.setDefaultDropAction(Qt.MoveAction)
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.setUniformItemSizes(True)
+        self.setAlternatingRowColors(True)
+        self.setSizeAdjustPolicy(QAbstractItemView.AdjustToContents)  # no nested scrollbar
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        h_pad = UIScaler.size(0.4)
+        v_pad = UIScaler.size(0.2)
+        self.setStyleSheet(f"""
+            QListWidget {{
+                border: none;
+                outline: none;
+            }}
+            QListWidget::item {{
+                padding: {v_pad}px {h_pad}px;
+            }}
+            QListWidget::item:selected {{
+                background-color: palette(highlight);
+                color: palette(highlighted-text);
+            }}
+        """)
+        self._update_callback = update_callback
+
+        sorted_keys = sorted(keys, key=lambda k: current_values.get(k, 999))
+        for key in sorted_keys:
+            label = format_option_name(key[len("column_index_"):])
+            item = QListWidgetItem()
+            item.setData(Qt.UserRole, key)
+            item.setData(Qt.UserRole + 1, label)
+            self.addItem(item)
+
+        self.model().rowsMoved.connect(self._sync_values)
+        self._sync_values()
+        self._fix_height()
+
+    def _fix_height(self):
+        """Set fixed height to show all items"""
+        v_pad = UIScaler.size(0.2)
+        row_h = self.fontMetrics().height() + v_pad * 2
+        self.setFixedHeight(row_h * self.count() + self.frameWidth() * 2)
+
+    def _sync_values(self):
+        """Update item text and value cache to reflect current order"""
+        for i in range(self.count()):
+            item = self.item(i)
+            label = item.data(Qt.UserRole + 1)
+            item.setText(f"{i + 1}. {label}")
+            self._update_callback(item.data(Qt.UserRole), i + 1)
+
+    def reset_to_defaults(self, default_values: dict):
+        """Re-sort items to default order"""
+        items = []
+        for i in range(self.count()):
+            item = self.item(i)
+            items.append((item.data(Qt.UserRole), item.data(Qt.UserRole + 1)))
+        items.sort(key=lambda t: default_values.get(t[0], 999))
+        self.clear()
+        for key, label in items:
+            new_item = QListWidgetItem()
+            new_item.setData(Qt.UserRole, key)
+            new_item.setData(Qt.UserRole + 1, label)
+            self.addItem(new_item)
+        self._sync_values()
 
 
 @singleton_dialog(ConfigType.CONFIG)
@@ -293,18 +359,8 @@ class UserConfig(BaseDialog):
         option_width: int = 9,
         section_grouper: SectionGrouper | None = None,
     ):
-        """
-        Args:
-            key_name: config key name.
-            cfg_type: config type name from "ConfigType".
-            user_setting: user setting dictionary, ex. cfg.user.setting.
-            default_setting: default setting dictionary, ex. cfg.default.setting.
-            reload_func: config reload (callback) function.
-            option_width: option column width in pixels.
-            section_grouper: grouper instance that determines the section layout.
-                             Defaults to SectionGrouper() if not provided.
-        """
         super().__init__(parent)
+        self.setWindowFlag(Qt.WindowMaximizeButtonHint, True)
         self.set_config_title(format_option_name(key_name), set_preset_name(cfg_type))
 
         self.reloading = reload_func
@@ -330,6 +386,7 @@ class UserConfig(BaseDialog):
         self.option_string: dict = {}
         self.option_integer: dict = {}
         self.option_float: dict = {}
+        self.option_column_order: dict = {}  # key -> ColumnIndexList widget
 
         # Section widgets and current column count (used for dynamic reflow)
         self._section_widgets: list[QFrame] = []
@@ -398,9 +455,8 @@ class UserConfig(BaseDialog):
         if new_w != self.width() or new_h != self.height():
             self.resize(new_w, new_h)
 
-    # -------------------- Search / Filter --------------------
     def _on_search_text_changed(self):
-        """Restart the debounce timer when text changes."""
+        """Restart debounce timer"""
         self.filter_timer.start(200)  # milliseconds
 
     def _apply_filter(self):
@@ -423,6 +479,7 @@ class UserConfig(BaseDialog):
         self.option_string.clear()
         self.option_integer.clear()
         self.option_float.clear()
+        self.option_column_order.clear()
 
         # Group the filtered keys and create new section frames
         sections = self.section_grouper.group_keys(keys)
@@ -440,14 +497,12 @@ class UserConfig(BaseDialog):
         new_container = self._arrange_columns(self._num_columns)
         self._scroll_box.setWidget(new_container)
 
-    # -------------------- Value cache --------------------
     def _update_current_value(self, key, value):
-        """Update the central value cache when an editor changes."""
+        """Update value cache"""
         self._current_values[key] = value
 
-    # -------------------- Editor creation --------------------
     def _create_editor_for_key(self, key: str) -> QWidget:
-        """Create and register an editor widget for the given key, using cached value."""
+        """Create editor widget for key"""
         current_val = self._current_values[key]
         default_val = self.default_setting[self.key_name][key]
 
@@ -603,9 +658,47 @@ class UserConfig(BaseDialog):
         self.option_float[key] = editor
         return editor
 
-    # -------------------- Layout building --------------------
+    def _create_column_index_frame(self, title: str | None, keys: list) -> QFrame:
+        """Create drag-and-drop frame for display order settings"""
+        layout = QVBoxLayout()
+        layout.setAlignment(Qt.AlignTop)
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        if title is not None:
+            header_text = (
+                format_option_name(self.key_name) if title == "" else "Display Order"
+            )
+            title_label = QLabel(f"<b>{header_text}</b>")
+            font = title_label.font()
+            font.setPointSize(font.pointSize() + 1)
+            title_label.setFont(font)
+            title_label.setStyleSheet("""
+                background-color: palette(dark);
+                color: palette(bright-text);
+                border-bottom: 2px solid palette(mid);
+                padding: 4px;
+            """)
+            layout.addWidget(title_label)
+
+        list_widget = ColumnIndexList(
+            keys, self._current_values, self._update_current_value, parent=self
+        )
+        for key in keys:
+            self.option_column_order[key] = list_widget
+        layout.addWidget(list_widget)
+
+        frame = QFrame()
+        frame.setObjectName("sectionFrame")
+        frame.setLayout(layout)
+        frame.setProperty("estimated_rows", len(keys) + (2 if title is not None else 1))
+        return frame
+
     def _create_section_frame(self, title: str | None, keys: list) -> QFrame:
-        """Create a frame containing one section with title bar and alternating rows."""
+        """Create section frame with title bar and alternating rows"""
+        # column_index_* keys get a drag-and-drop list instead of integer editors
+        if keys and all(k.startswith("column_index_") for k in keys):
+            return self._create_column_index_frame(title, keys)
         layout = QGridLayout()
         layout.setAlignment(Qt.AlignTop)
         layout.setSpacing(0)
@@ -724,9 +817,8 @@ class UserConfig(BaseDialog):
         container.setLayout(main_layout)
         return container
 
-    # -------------------- Resize event --------------------
     def resizeEvent(self, event):
-        """Reflow columns when the window becomes wide or narrow enough."""
+        """Reflow columns on window resize"""
         super().resizeEvent(event)
         if not self._section_widgets:
             return
@@ -735,9 +827,8 @@ class UserConfig(BaseDialog):
         if new_num != self._num_columns:
             self._scroll_box.setWidget(self._arrange_columns(new_num))
 
-    # -------------------- Focus searchbar --------------------
     def keyPressEvent(self, event):
-        """Vang Ctrl+F af om focus naar de zoekbalk te verplaatsen."""
+        """Focus search bar on Ctrl+F"""
         if event.matches(QKeySequence.Find):
             self.search_edit.setFocus()
             self.search_edit.selectAll()
@@ -745,7 +836,6 @@ class UserConfig(BaseDialog):
         else:
             super().keyPressEvent(event)
 
-    # -------------------- Apply / Save / Reset --------------------
     def applying(self):
         """Save & apply"""
         self.save_setting(is_apply=True)
@@ -793,6 +883,15 @@ class UserConfig(BaseDialog):
                 default = str(editor.defaults)
                 editor.setText(default)
                 self._current_values[key] = float(default) if '.' in default else int(default)
+            seen_column_lists: set = set()
+            for key, lw in self.option_column_order.items():
+                if id(lw) not in seen_column_lists:
+                    seen_column_lists.add(id(lw))
+                    all_keys = [k for k, w in self.option_column_order.items() if w is lw]
+                    default_vals = {
+                        k: self.default_setting[self.key_name][k] for k in all_keys
+                    }
+                    lw.reset_to_defaults(default_vals)
 
     def save_setting(self, is_apply: bool):
         """Save setting from current cache, validate, and write to config."""
@@ -859,6 +958,9 @@ class UserConfig(BaseDialog):
             else:
                 self.value_error_message("number", key)
                 error_found = True
+
+        for key in self.option_column_order:
+            user_setting[key] = self._current_values[key]
 
         # Abort saving if error found
         if error_found:

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -28,7 +28,7 @@ import time
 from typing import Callable
 
 from PySide2.QtCore import QPoint, Qt, QTimer
-from PySide2.QtGui import QFontDatabase, QKeySequence
+from PySide2.QtGui import QFontDatabase, QKeySequence, QShortcut
 from PySide2.QtWidgets import (
     QAbstractItemView,
     QApplication,
@@ -45,7 +45,6 @@ from PySide2.QtWidgets import (
     QMenu,
     QMessageBox,
     QScrollArea,
-    QShortcut,
     QSpinBox,
     QSplitter,
     QVBoxLayout,

--- a/tinypedal/ui/config_preview.py
+++ b/tinypedal/ui/config_preview.py
@@ -142,7 +142,12 @@ class WidgetPreview(QFrame):
         self._active_widget = widget
         widget.show()
 
-    def closeEvent(self, event):
-        """Clean up on close"""
+    def cleanup(self):
+        """Stop all timers and remove active widget; call before parent dialog closes"""
+        self._debounce.stop()
         self._remove_active()
+
+    def closeEvent(self, event):
+        """Clean up on close (only fires when used as a top-level window)"""
+        self.cleanup()
         super().closeEvent(event)

--- a/tinypedal/ui/config_preview.py
+++ b/tinypedal/ui/config_preview.py
@@ -1,0 +1,148 @@
+#  TinyPedal is an open-source overlay application for racing simulation.
+#  Copyright (C) 2022-2026 TinyPedal developers, see contributors.md file
+#
+#  This file is part of TinyPedal.
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Widget preview panel for config dialog
+"""
+
+import copy
+import importlib
+
+from PySide2.QtCore import Qt, QTimer
+from PySide2.QtWidgets import (
+    QFrame,
+    QLabel,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..setting import cfg
+
+
+class WidgetPreview(QFrame):
+    """Embedded live preview of the widget being configured"""
+
+    _DEBOUNCE_MS = 500
+
+    def __init__(self, key_name: str, parent=None):
+        super().__init__(parent)
+        self._key_name = key_name
+        self._active_widget = None
+        self._pending_values: dict = {}
+
+        try:
+            self._module = importlib.import_module(f"tinypedal.widget.{key_name}")
+            self._available = True
+        except ImportError:
+            self._module = None
+            self._available = False
+
+        self._debounce = QTimer(self)
+        self._debounce.setSingleShot(True)
+        self._debounce.timeout.connect(self._rebuild)
+
+        title = QLabel("Preview")
+        title.setAlignment(Qt.AlignCenter)
+        title.setStyleSheet("""
+            background-color: palette(dark);
+            color: palette(bright-text);
+            border-bottom: 2px solid palette(mid);
+            padding: 4px;
+            font-weight: bold;
+        """)
+
+        self._inner = QWidget()
+        inner_layout = QVBoxLayout()
+        inner_layout.setAlignment(Qt.AlignHCenter | Qt.AlignTop)
+        inner_layout.setContentsMargins(8, 8, 8, 8)
+        self._inner.setLayout(inner_layout)
+        self._inner_layout = inner_layout
+
+        scroll = QScrollArea()
+        scroll.setWidget(self._inner)
+        scroll.setWidgetResizable(True)
+
+        layout = QVBoxLayout()
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(title)
+        layout.addWidget(scroll)
+        self.setLayout(layout)
+
+        if self._available:
+            self._rebuild()
+
+    @property
+    def available(self) -> bool:
+        """True if a widget module exists for this key"""
+        return self._available
+
+    def schedule_refresh(self, current_values: dict):
+        """Schedule a preview rebuild after debounce delay"""
+        self._pending_values = current_values.copy()
+        self._debounce.start(self._DEBOUNCE_MS)
+
+    def _remove_active(self):
+        """Stop and remove the currently active preview widget"""
+        if self._active_widget is None:
+            return
+        self._active_widget._update_timer.stop()
+        self._inner_layout.removeWidget(self._active_widget)
+        self._active_widget.deleteLater()
+        self._active_widget = None
+
+    def _rebuild(self):
+        """Rebuild preview widget with current pending values"""
+        self._remove_active()
+        if not self._available:
+            return
+
+        # Apply pending (unsaved) values to a deep copy of the settings
+        original = cfg.user.setting[self._key_name]
+        patched = copy.deepcopy(original)
+        for key, value in self._pending_values.items():
+            if key in patched:
+                patched[key] = value
+
+        # Temporarily swap in patched settings so the widget reads them at init
+        cfg.user.setting[self._key_name] = patched
+        try:
+            widget = self._module.Realtime(cfg, self._key_name)
+        except Exception:
+            cfg.user.setting[self._key_name] = original
+            return
+        cfg.user.setting[self._key_name] = original
+
+        # Embed as plain child widget, strip overlay window flags
+        widget.setParent(self._inner)
+        widget.setWindowFlags(Qt.Widget)
+        widget.setAttribute(Qt.WA_TranslucentBackground, False)
+
+        # Start timer directly - bypassing start() which would connect global
+        # overlay signals and briefly show the widget as a floating overlay
+        widget._update_timer.start(widget._update_interval, widget)
+
+        self._inner_layout.insertWidget(0, widget)
+        self._active_widget = widget
+        widget.show()
+
+    def closeEvent(self, event):
+        """Clean up on close"""
+        self._remove_active()
+        super().closeEvent(event)

--- a/tinypedal/ui/config_preview.py
+++ b/tinypedal/ui/config_preview.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 from PySide2.QtCore import Qt, QTimer
 from PySide2.QtWidgets import (
     QFrame,
+    QGridLayout,
     QLabel,
     QScrollArea,
     QVBoxLayout,
@@ -48,6 +49,8 @@ class WidgetPreview(QFrame):
         self._key_name = key_name
         self._active_widget = None
         self._pending_values: dict = {}
+        self._element_map: dict = {}
+        self._last_applied_values: dict = {}
 
         try:
             self._module = importlib.import_module(f"tinypedal.widget.{key_name}")
@@ -97,8 +100,21 @@ class WidgetPreview(QFrame):
         return self._available
 
     def schedule_refresh(self, current_values: dict):
-        """Schedule a preview rebuild after debounce delay"""
+        """Schedule a preview rebuild, or fast-toggle visibility for show_* changes"""
         self._pending_values = current_values.copy()
+
+        if self._active_widget and self._element_map and self._last_applied_values:
+            changed = {
+                k: v for k, v in current_values.items()
+                if self._last_applied_values.get(k) != v
+            }
+            if not changed:
+                return
+            if all(k in self._element_map for k in changed):
+                self._apply_show_hide(current_values)
+                self._last_applied_values = current_values.copy()
+                return
+
         self._debounce.start(self._DEBOUNCE_MS)
 
     def _remove_active(self):
@@ -106,10 +122,12 @@ class WidgetPreview(QFrame):
         if self._active_widget is None:
             return
         self._active_widget._update_timer.stop()
-        self._active_widget.hide()  # hide immediately so it doesn't linger behind the new widget
+        self._active_widget.hide()
         self._inner_layout.removeWidget(self._active_widget)
         self._active_widget.deleteLater()
         self._active_widget = None
+        self._element_map = {}
+        self._last_applied_values = {}
 
     def _rebuild(self):
         """Rebuild preview widget with current pending values"""
@@ -124,6 +142,17 @@ class WidgetPreview(QFrame):
             if key in patched:
                 patched[key] = value
 
+        # Force all show_* settings to True (where they have a matching
+        # column_index_*) so every element is created.  We hide the ones
+        # the user toggled off *after* widget construction.
+        forced_show = {}
+        for key in patched:
+            if key.startswith("show_"):
+                col_key = f"column_index_{key[5:]}"
+                if col_key in patched and not patched[key]:
+                    forced_show[key] = False
+                    patched[key] = True
+
         # Temporarily swap in patched settings so the widget reads them at init
         cfg.user.setting[self._key_name] = patched
         try:
@@ -134,18 +163,120 @@ class WidgetPreview(QFrame):
             return
         cfg.user.setting[self._key_name] = original
 
-        # Embed as plain child widget, strip overlay window flags
+        # Embed as plain child widget, strip overlay window flags.
+        # move(0, 0) resets the screen-coordinate position stored by Base.__init__
+        # so the widget starts at a visible location before the layout repositions it.
         widget.setParent(self._inner)
         widget.setWindowFlags(Qt.Widget)
         widget.setAttribute(Qt.WA_TranslucentBackground, False)
+        widget.move(0, 0)
 
         # Start timer directly - bypassing start() which would connect global
         # overlay signals and briefly show the widget as a floating overlay
         widget._update_timer.start(widget._update_interval, widget)
 
-        self._inner_layout.insertWidget(0, widget)
+        # Populate elements with real data before showing so placeholders
+        # like "BATTERY" are replaced immediately.
+        try:
+            widget.timerEvent(None)
+        except Exception:
+            pass
+
+        # Build the element map and apply visibility BEFORE showing
+        # to prevent a flash of hidden elements.
         self._active_widget = widget
+        self._element_map = self._build_element_map(widget, patched)
+        # Use pending_values if available, otherwise fall back to the original
+        # config so the very first schedule_refresh can detect real changes.
+        if self._pending_values:
+            self._last_applied_values = self._pending_values.copy()
+        else:
+            self._last_applied_values = dict(original)
+        if self._element_map and forced_show:
+            self._apply_show_hide(self._pending_values)
+
+        self._inner_layout.insertWidget(0, widget)
         widget.show()
+
+    def _build_element_map(self, widget, config):
+        """Map show_* keys to their QWidget elements in the grid layout.
+
+        Returns a dict of {show_key: (QWidget, original_column_index)}.
+        Returns empty dict if the widget doesn't use a simple QGridLayout.
+        """
+        layout = widget.layout()
+        if not isinstance(layout, QGridLayout):
+            return {}
+
+        is_vertical = config.get("layout", 0) == 0
+
+        # Map grid positions to widgets
+        pos_to_widget = {}
+        for i in range(layout.count()):
+            item = layout.itemAt(i)
+            if item and item.widget():
+                row, col, _, _ = layout.getItemPosition(i)
+                pos_to_widget[(row, col)] = item.widget()
+
+        element_map = {}
+        for key in config:
+            if not key.startswith("show_"):
+                continue
+            col_key = f"column_index_{key[5:]}"
+            if col_key not in config:
+                continue
+            col_idx = config[col_key]
+            pos = (col_idx, 0) if is_vertical else (0, col_idx)
+            w = pos_to_widget.get(pos)
+            if w:
+                element_map[key] = (w, col_idx)
+
+        return element_map
+
+    def _apply_show_hide(self, values):
+        """Toggle visibility of mapped elements and relayout to avoid gaps"""
+        if not self._element_map or not self._active_widget:
+            return
+
+        layout = self._active_widget.layout()
+        if not isinstance(layout, QGridLayout):
+            return
+
+        is_vertical = self._active_widget.wcfg.get("layout", 0) == 0
+
+        # Remove all mapped elements from the grid
+        for _show_key, (widget, _col_idx) in self._element_map.items():
+            layout.removeWidget(widget)
+
+        # Separate into visible / hidden, each sorted by column_index
+        visible = []
+        hidden = []
+        for show_key, (widget, col_idx) in self._element_map.items():
+            if values.get(show_key, True):
+                visible.append((col_idx, widget))
+            else:
+                hidden.append((col_idx, widget))
+
+        visible.sort(key=lambda x: x[0])
+        hidden.sort(key=lambda x: x[0])
+
+        # Re-add: visible elements first (in order), hidden elements at the end
+        idx = 0
+        for _col_idx, widget in visible:
+            widget.setVisible(True)
+            if is_vertical:
+                layout.addWidget(widget, idx, 0)
+            else:
+                layout.addWidget(widget, 0, idx)
+            idx += 1
+
+        for _col_idx, widget in hidden:
+            widget.setVisible(False)
+            if is_vertical:
+                layout.addWidget(widget, idx, 0)
+            else:
+                layout.addWidget(widget, 0, idx)
+            idx += 1
 
     def cleanup(self):
         """Stop all timers and remove active widget; call before parent dialog closes"""

--- a/tinypedal/ui/config_preview.py
+++ b/tinypedal/ui/config_preview.py
@@ -99,6 +99,7 @@ class WidgetPreview(QFrame):
         """True if a widget module exists for this key"""
         return self._available
 
+
     def schedule_refresh(self, current_values: dict):
         """Schedule a preview rebuild, or fast-toggle visibility for show_* changes"""
         self._pending_values = current_values.copy()

--- a/tinypedal/ui/config_preview.py
+++ b/tinypedal/ui/config_preview.py
@@ -22,6 +22,9 @@ Widget preview panel for config dialog
 
 import copy
 import importlib
+import logging
+
+logger = logging.getLogger(__name__)
 
 from PySide2.QtCore import Qt, QTimer
 from PySide2.QtWidgets import (
@@ -103,6 +106,7 @@ class WidgetPreview(QFrame):
         if self._active_widget is None:
             return
         self._active_widget._update_timer.stop()
+        self._active_widget.hide()  # hide immediately so it doesn't linger behind the new widget
         self._inner_layout.removeWidget(self._active_widget)
         self._active_widget.deleteLater()
         self._active_widget = None
@@ -125,6 +129,7 @@ class WidgetPreview(QFrame):
         try:
             widget = self._module.Realtime(cfg, self._key_name)
         except Exception:
+            logger.error("Preview rebuild failed for %s", self._key_name, exc_info=True)
             cfg.user.setting[self._key_name] = original
             return
         cfg.user.setting[self._key_name] = original

--- a/tinypedal/ui/dragdroplist.py
+++ b/tinypedal/ui/dragdroplist.py
@@ -79,7 +79,6 @@ class DragDropOrderList(QWidget):
         self._callback = on_reorder_callback
         self._row_height = row_height
         self._dimmed_keys: set[str] = set()
-        self._dim_opacity: float = 1.0
         self.setAcceptDrops(True)
 
         # Drop indicator line (shown between rows during drag)
@@ -225,16 +224,9 @@ class DragDropOrderList(QWidget):
             row = box.itemAt(i).widget()
             if isinstance(row, OrderRow):
                 if row.key in self._dimmed_keys:
-                    op = self._dim_opacity
-                    row.setStyleSheet(
-                        f"background-color: rgba(128, 128, 128, {op});"
-                    )
-                    row.drag_label.setStyleSheet(
-                        f"color: rgba(128, 128, 128, {op});"
-                    )
-                    row.number_label.setStyleSheet(
-                        f"color: rgba(128, 128, 128, {op});"
-                    )
+                    row.setStyleSheet("background-color: palette(window);")
+                    row.drag_label.setStyleSheet("color: palette(mid);")
+                    row.number_label.setStyleSheet("color: palette(mid);")
                 else:
                     if num % 2 == 0:
                         row.setStyleSheet("background-color: palette(alternate-base);")
@@ -269,10 +261,9 @@ class DragDropOrderList(QWidget):
                 keys.append(row.key)
         return keys
 
-    def set_dimmed_keys(self, keys: set[str], opacity: float):
+    def set_dimmed_keys(self, keys: set[str]):
         """Update which keys are dimmed and refresh row colors"""
         self._dimmed_keys = keys
-        self._dim_opacity = opacity
         self._update_row_colors()
 
     def reset_to_defaults(self, default_values: dict):

--- a/tinypedal/ui/dragdroplist.py
+++ b/tinypedal/ui/dragdroplist.py
@@ -78,6 +78,8 @@ class DragDropOrderList(QWidget):
 
         self._callback = on_reorder_callback
         self._row_height = row_height
+        self._dimmed_keys: set[str] = set()
+        self._dim_opacity: float = 1.0
         self.setAcceptDrops(True)
 
         # Drop indicator line (shown between rows during drag)
@@ -85,6 +87,9 @@ class DragDropOrderList(QWidget):
         self._drop_indicator.setFixedHeight(2)
         self._drop_indicator.setStyleSheet("background-color: palette(highlight);")
         self._drop_indicator.hide()
+
+        # Rows whose number labels are currently highlighted during drag
+        self._highlighted_rows: list[OrderRow] = []
 
         # Main layout
         box = QVBoxLayout()
@@ -142,9 +147,23 @@ class DragDropOrderList(QWidget):
         n = self._find_insert_index(e.pos())
         box.insertWidget(n, self._drop_indicator)
         self._drop_indicator.show()
+
+        # Highlight number labels on adjacent rows
+        self._clear_highlight()
+        for offset in (n - 1, n + 1):
+            if 0 <= offset < box.count():
+                row = box.itemAt(offset).widget()
+                if isinstance(row, OrderRow):
+                    row.number_label.setStyleSheet(
+                        "background-color: palette(highlight);"
+                        "color: palette(highlighted-text);"
+                    )
+                    self._highlighted_rows.append(row)
+
         e.accept()
 
     def dragLeaveEvent(self, e):
+        self._clear_highlight()
         if self._drop_indicator.parent() == self:
             self.layout().removeWidget(self._drop_indicator)
             self._drop_indicator.hide()
@@ -154,6 +173,8 @@ class DragDropOrderList(QWidget):
         source_label = e.source()
         if not isinstance(source_label, DraggableLabel):
             return
+
+        self._clear_highlight()
 
         box = self.layout()
 
@@ -180,6 +201,12 @@ class DragDropOrderList(QWidget):
     #  Visual updates
     # ------------------------------------------------------------------
 
+    def _clear_highlight(self):
+        """Remove highlight styling from any previously highlighted number labels"""
+        for row in self._highlighted_rows:
+            row.number_label.setStyleSheet("")
+        self._highlighted_rows.clear()
+
     def _update_row_numbers(self):
         """Set row numbers (1-based) according to current order"""
         num = 1
@@ -191,16 +218,30 @@ class DragDropOrderList(QWidget):
                 num += 1
 
     def _update_row_colors(self):
-        """Apply alternating row background colors"""
+        """Apply alternating row background colors, with dimming for filtered rows"""
         num = 0
         box = self.layout()
         for i in range(box.count()):
             row = box.itemAt(i).widget()
             if isinstance(row, OrderRow):
-                if num % 2 == 0:
-                    row.setStyleSheet("background-color: palette(alternate-base);")
+                if row.key in self._dimmed_keys:
+                    op = self._dim_opacity
+                    row.setStyleSheet(
+                        f"background-color: rgba(128, 128, 128, {op});"
+                    )
+                    row.drag_label.setStyleSheet(
+                        f"color: rgba(128, 128, 128, {op});"
+                    )
+                    row.number_label.setStyleSheet(
+                        f"color: rgba(128, 128, 128, {op});"
+                    )
                 else:
-                    row.setStyleSheet("background-color: palette(base);")
+                    if num % 2 == 0:
+                        row.setStyleSheet("background-color: palette(alternate-base);")
+                    else:
+                        row.setStyleSheet("background-color: palette(base);")
+                    row.drag_label.setStyleSheet("")
+                    row.number_label.setStyleSheet("")
                 num += 1
 
     def _emit_reorder(self):
@@ -227,6 +268,12 @@ class DragDropOrderList(QWidget):
             if isinstance(row, OrderRow):
                 keys.append(row.key)
         return keys
+
+    def set_dimmed_keys(self, keys: set[str], opacity: float):
+        """Update which keys are dimmed and refresh row colors"""
+        self._dimmed_keys = keys
+        self._dim_opacity = opacity
+        self._update_row_colors()
 
     def reset_to_defaults(self, default_values: dict):
         """Re-sort rows to match *default_values* ordering"""

--- a/tinypedal/ui/dragdroplist.py
+++ b/tinypedal/ui/dragdroplist.py
@@ -1,0 +1,253 @@
+"""Drag-and-drop reorderable list widget for display order settings"""
+
+from PySide2.QtCore import Qt, QMimeData
+from PySide2.QtGui import QDrag, QPixmap
+from PySide2.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame
+
+DEFAULT_ROW_HEIGHT = 24
+
+
+class DraggableLabel(QLabel):
+    """Label that initiates a drag operation on mouse move"""
+
+    def __init__(self, key: str, text: str, parent=None):
+        super().__init__(text, parent)
+        self.key = key
+        self.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        self.setIndent(5)
+
+    def mouseMoveEvent(self, e):
+        if e.buttons() == Qt.LeftButton:
+            drag = QDrag(self)
+            mime = QMimeData()
+            drag.setMimeData(mime)
+
+            pixmap = QPixmap(self.size())
+            self.render(pixmap)
+            drag.setPixmap(pixmap)
+
+            drag.exec_(Qt.MoveAction)
+
+
+class OrderRow(QWidget):
+    """Single row: static number label + draggable text label"""
+
+    def __init__(self, key: str, label: str, row_height: int, parent=None):
+        super().__init__(parent)
+        self.key = key
+        self.setFixedHeight(row_height)
+        self.setContentsMargins(0, 0, 0, 0)
+
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # Number (static, square)
+        self.number_label = QLabel()
+        self.number_label.setAlignment(Qt.AlignCenter)
+        self.number_label.setFixedWidth(row_height)
+        self.number_label.setContentsMargins(0, 0, 0, 0)
+
+        # Draggable label (shows the text)
+        self.drag_label = DraggableLabel(key, label, self)
+        self.drag_label.setFixedHeight(row_height)
+        self.drag_label.setContentsMargins(0, 0, 0, 0)
+
+        layout.addWidget(self.number_label)
+        layout.addWidget(self.drag_label, 1)
+        self.setLayout(layout)
+
+    def set_number(self, number: int):
+        """Set the row number displayed on the left"""
+        self.number_label.setText(str(number))
+
+
+class DragDropOrderList(QWidget):
+    """Container that handles drag-and-drop reordering and fires a callback"""
+
+    def __init__(self, items: list[tuple[str, str]], on_reorder_callback,
+                 row_height: int = DEFAULT_ROW_HEIGHT, parent=None):
+        """
+        Parameters
+        ----------
+        items : list of (key, label) tuples
+        on_reorder_callback : callable receiving a list of keys
+        row_height : fixed height per row (pixels)
+        """
+        super().__init__(parent)
+
+        self._callback = on_reorder_callback
+        self._row_height = row_height
+        self.setAcceptDrops(True)
+
+        # Drop indicator line (shown between rows during drag)
+        self._drop_indicator = QFrame(self)
+        self._drop_indicator.setFixedHeight(2)
+        self._drop_indicator.setStyleSheet("background-color: palette(highlight);")
+        self._drop_indicator.hide()
+
+        # Main layout
+        box = QVBoxLayout()
+        box.setSpacing(0)
+        box.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(box)
+
+        for key, label in items:
+            self._add_row(key, label)
+
+        self._update_row_numbers()
+        self._update_row_colors()
+
+    # ------------------------------------------------------------------
+    #  Row helpers
+    # ------------------------------------------------------------------
+
+    def _add_row(self, key: str, label: str):
+        """Append a new row at the end"""
+        row = OrderRow(key, label, self._row_height, self)
+        self.layout().addWidget(row)
+
+    def _find_insert_index(self, pos):
+        """Return layout index where a row should be inserted for *pos*"""
+        box = self.layout()
+        n = 0
+        while n < box.count():
+            w = box.itemAt(n).widget()
+            if w is not None and pos.y() < w.y() + w.height() // 2:
+                break
+            n += 1
+        return n
+
+    # ------------------------------------------------------------------
+    #  Drag-and-drop events
+    # ------------------------------------------------------------------
+
+    def dragEnterEvent(self, e):
+        e.accept()
+
+    def dragMoveEvent(self, e):
+        source_label = e.source()
+        if not isinstance(source_label, DraggableLabel):
+            e.ignore()
+            return
+
+        box = self.layout()
+
+        # Remove indicator if still in the layout
+        if self._drop_indicator.parent() == self:
+            box.removeWidget(self._drop_indicator)
+            self._drop_indicator.hide()
+
+        # Insert indicator at calculated position
+        n = self._find_insert_index(e.pos())
+        box.insertWidget(n, self._drop_indicator)
+        self._drop_indicator.show()
+        e.accept()
+
+    def dragLeaveEvent(self, e):
+        if self._drop_indicator.parent() == self:
+            self.layout().removeWidget(self._drop_indicator)
+            self._drop_indicator.hide()
+        e.accept()
+
+    def dropEvent(self, e):
+        source_label = e.source()
+        if not isinstance(source_label, DraggableLabel):
+            return
+
+        box = self.layout()
+
+        # Remove the drop indicator
+        if self._drop_indicator.parent() == self:
+            box.removeWidget(self._drop_indicator)
+            self._drop_indicator.hide()
+
+        source_row = source_label.parent()
+        if not isinstance(source_row, OrderRow):
+            return
+
+        # Remove row, calculate new position, re-insert
+        box.removeWidget(source_row)
+        n = self._find_insert_index(e.pos())
+        box.insertWidget(n, source_row)
+        e.accept()
+
+        self._update_row_numbers()
+        self._update_row_colors()
+        self._emit_reorder()
+
+    # ------------------------------------------------------------------
+    #  Visual updates
+    # ------------------------------------------------------------------
+
+    def _update_row_numbers(self):
+        """Set row numbers (1-based) according to current order"""
+        num = 1
+        box = self.layout()
+        for i in range(box.count()):
+            row = box.itemAt(i).widget()
+            if isinstance(row, OrderRow):
+                row.set_number(num)
+                num += 1
+
+    def _update_row_colors(self):
+        """Apply alternating row background colors"""
+        num = 0
+        box = self.layout()
+        for i in range(box.count()):
+            row = box.itemAt(i).widget()
+            if isinstance(row, OrderRow):
+                if num % 2 == 0:
+                    row.setStyleSheet("background-color: palette(alternate-base);")
+                else:
+                    row.setStyleSheet("background-color: palette(base);")
+                num += 1
+
+    def _emit_reorder(self):
+        """Collect current key order and invoke the callback"""
+        if self._callback:
+            keys = []
+            box = self.layout()
+            for i in range(box.count()):
+                row = box.itemAt(i).widget()
+                if isinstance(row, OrderRow):
+                    keys.append(row.key)
+            self._callback(keys)
+
+    # ------------------------------------------------------------------
+    #  Public API
+    # ------------------------------------------------------------------
+
+    def get_key_order(self):
+        """Return the current list of keys in display order"""
+        keys = []
+        box = self.layout()
+        for i in range(box.count()):
+            row = box.itemAt(i).widget()
+            if isinstance(row, OrderRow):
+                keys.append(row.key)
+        return keys
+
+    def reset_to_defaults(self, default_values: dict):
+        """Re-sort rows to match *default_values* ordering"""
+        box = self.layout()
+
+        # Collect all OrderRow widgets
+        rows = []
+        for i in range(box.count()):
+            row = box.itemAt(i).widget()
+            if isinstance(row, OrderRow):
+                rows.append(row)
+
+        # Remove from layout (without deleting)
+        for row in rows:
+            box.removeWidget(row)
+
+        # Re-insert sorted by default value
+        rows.sort(key=lambda r: default_values.get(r.key, 999))
+        for row in rows:
+            box.addWidget(row)
+
+        self._update_row_numbers()
+        self._update_row_colors()
+        self._emit_reorder()

--- a/tinypedal/ui/dragdroplist.py
+++ b/tinypedal/ui/dragdroplist.py
@@ -1,20 +1,18 @@
-"""Drag-and-drop reorderable list widget for display order settings"""
-
-from PySide2.QtCore import Qt, QMimeData
-from PySide2.QtGui import QDrag, QPixmap
+from PySide2.QtCore import Qt, QMimeData, QEvent, Signal
+from PySide2.QtGui import QDrag, QPixmap, QMouseEvent
 from PySide2.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QFrame
 
 DEFAULT_ROW_HEIGHT = 24
 
 
-class DraggableLabel(QLabel):
-    """Label that initiates a drag operation on mouse move"""
-
-    def __init__(self, key: str, text: str, parent=None):
-        super().__init__(text, parent)
-        self.key = key
-        self.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
-        self.setIndent(5)
+class DragHandle(QLabel):
+    """Hendel waarmee de rij versleept kan worden."""
+    def __init__(self, parent=None):
+        super().__init__(" ⋮⋮ ", parent)  # unicode grijper symbool
+        self.setAlignment(Qt.AlignCenter)
+        self.setFixedWidth(20)
+        self.setStyleSheet("background-color: palette(mid); color: palette(text);")
+        self.setCursor(Qt.OpenHandCursor)
 
     def mouseMoveEvent(self, e):
         if e.buttons() == Qt.LeftButton:
@@ -30,11 +28,11 @@ class DraggableLabel(QLabel):
 
 
 class OrderRow(QWidget):
-    """Single row: static number label + draggable text label"""
-
+    """Eén rij in de lijst: nummer (statisch), tekst (klikbaar voor highlight), hendel (sleepbaar)."""
     def __init__(self, key: str, label: str, row_height: int, parent=None):
         super().__init__(parent)
         self.key = key
+        self.label = label
         self.setFixedHeight(row_height)
         self.setContentsMargins(0, 0, 0, 0)
 
@@ -42,59 +40,64 @@ class OrderRow(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        # Number (static, square)
+        # Nummerlabel – klikbaar
         self.number_label = QLabel()
         self.number_label.setAlignment(Qt.AlignCenter)
         self.number_label.setFixedWidth(row_height)
         self.number_label.setContentsMargins(0, 0, 0, 0)
+        self.number_label.setCursor(Qt.PointingHandCursor)  # handje
+        self.number_label.setStyleSheet("""
+            QLabel:hover {
+                background-color: rgba(0, 120, 215, 0.2);  /* lichte blauwe hover */
+            }
+        """)
 
-        # Draggable label (shows the text)
-        self.drag_label = DraggableLabel(key, label, self)
-        self.drag_label.setFixedHeight(row_height)
-        self.drag_label.setContentsMargins(0, 0, 0, 0)
+        # Tekstlabel – klikbaar
+        self.text_label = QLabel(label)
+        self.text_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        self.text_label.setIndent(5)
+        self.text_label.setFixedHeight(row_height)
+        self.text_label.setContentsMargins(0, 0, 0, 0)
+        self.text_label.setCursor(Qt.PointingHandCursor)   # handje
+        self.text_label.setStyleSheet("""
+            QLabel:hover {
+                background-color: rgba(0, 120, 215, 0.2);
+            }
+        """)
+
+        # Hendel – sleepbaar
+        self.drag_handle = DragHandle(self)
+        self.drag_handle.setFixedHeight(row_height)
 
         layout.addWidget(self.number_label)
-        layout.addWidget(self.drag_label, 1)
+        layout.addWidget(self.text_label, 1)
+        layout.addWidget(self.drag_handle)
         self.setLayout(layout)
 
     def set_number(self, number: int):
-        """Set the row number displayed on the left"""
         self.number_label.setText(str(number))
 
-
 class DragDropOrderList(QWidget):
-    """Container that handles drag-and-drop reordering and fires a callback"""
+    """Container met drag & drop lijst. Emit sectionClicked(key) bij klik op tekst/nummer."""
+    sectionClicked = Signal(str)  # geeft de key van de aangeklikte rij
 
     def __init__(self, items: list[tuple[str, str]], on_reorder_callback,
                  row_height: int = DEFAULT_ROW_HEIGHT, parent=None):
-        """
-        Parameters
-        ----------
-        items : list of (key, label) tuples
-        on_reorder_callback : callable receiving a list of keys
-        row_height : fixed height per row (pixels)
-        """
         super().__init__(parent)
-
         self._callback = on_reorder_callback
         self._row_height = row_height
-        self._dimmed_keys: set[str] = set()
+        self._all_items = items[:]  # bewaar voor reset
         self.setAcceptDrops(True)
 
-        # Drop indicator line (shown between rows during drag)
-        self._drop_indicator = QFrame(self)
-        self._drop_indicator.setFixedHeight(2)
-        self._drop_indicator.setStyleSheet("background-color: palette(highlight);")
-        self._drop_indicator.hide()
+        self.drop_indicator = QFrame()
+        self.drop_indicator.setFixedHeight(2)
+        self.drop_indicator.setStyleSheet("background-color: blue;")
+        self.drop_indicator.hide()
 
-        # Rows whose number labels are currently highlighted during drag
-        self._highlighted_rows: list[OrderRow] = []
-
-        # Main layout
-        box = QVBoxLayout()
-        box.setSpacing(0)
-        box.setContentsMargins(0, 0, 0, 0)
-        self.setLayout(box)
+        self.layout = QVBoxLayout()
+        self.layout.setSpacing(0)
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(self.layout)
 
         for key, label in items:
             self._add_row(key, label)
@@ -102,190 +105,135 @@ class DragDropOrderList(QWidget):
         self._update_row_numbers()
         self._update_row_colors()
 
-    # ------------------------------------------------------------------
-    #  Row helpers
-    # ------------------------------------------------------------------
-
     def _add_row(self, key: str, label: str):
-        """Append a new row at the end"""
         row = OrderRow(key, label, self._row_height, self)
-        self.layout().addWidget(row)
+        self.layout.addWidget(row)
+        row.number_label.installEventFilter(self)
+        row.text_label.installEventFilter(self)
 
-    def _find_insert_index(self, pos):
-        """Return layout index where a row should be inserted for *pos*"""
-        box = self.layout()
-        n = 0
-        while n < box.count():
-            w = box.itemAt(n).widget()
-            if w is not None and pos.y() < w.y() + w.height() // 2:
-                break
-            n += 1
-        return n
-
-    # ------------------------------------------------------------------
-    #  Drag-and-drop events
-    # ------------------------------------------------------------------
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.MouseButtonPress:
+            mouse_event = QMouseEvent(event)
+            if mouse_event.button() == Qt.LeftButton:
+                parent_row = obj.parent()
+                if isinstance(parent_row, OrderRow):
+                    self.sectionClicked.emit(parent_row.key)
+        return super().eventFilter(obj, event)
 
     def dragEnterEvent(self, e):
-        e.accept()
+        if isinstance(e.source(), DragHandle):
+            e.accept()
+        else:
+            e.ignore()
 
     def dragMoveEvent(self, e):
-        source_label = e.source()
-        if not isinstance(source_label, DraggableLabel):
+        if not isinstance(e.source(), DragHandle):
             e.ignore()
             return
 
-        box = self.layout()
+        if self.drop_indicator.parent() == self:
+            self.layout.removeWidget(self.drop_indicator)
+            self.drop_indicator.hide()
 
-        # Remove indicator if still in the layout
-        if self._drop_indicator.parent() == self:
-            box.removeWidget(self._drop_indicator)
-            self._drop_indicator.hide()
+        pos = e.pos()
+        n = 0
+        while n < self.layout.count():
+            w = self.layout.itemAt(n).widget()
+            if pos.y() < w.y() + w.height() // 2:
+                break
+            n += 1
 
-        # Insert indicator at calculated position
-        n = self._find_insert_index(e.pos())
-        box.insertWidget(n, self._drop_indicator)
-        self._drop_indicator.show()
-
-        # Highlight number labels on adjacent rows
-        self._clear_highlight()
-        for offset in (n - 1, n + 1):
-            if 0 <= offset < box.count():
-                row = box.itemAt(offset).widget()
-                if isinstance(row, OrderRow):
-                    row.number_label.setStyleSheet(
-                        "background-color: palette(highlight);"
-                        "color: palette(highlighted-text);"
-                    )
-                    self._highlighted_rows.append(row)
-
+        self.layout.insertWidget(n, self.drop_indicator)
+        self.drop_indicator.show()
         e.accept()
 
     def dragLeaveEvent(self, e):
-        self._clear_highlight()
-        if self._drop_indicator.parent() == self:
-            self.layout().removeWidget(self._drop_indicator)
-            self._drop_indicator.hide()
+        if self.drop_indicator.parent() == self:
+            self.layout.removeWidget(self.drop_indicator)
+            self.drop_indicator.hide()
         e.accept()
 
     def dropEvent(self, e):
-        source_label = e.source()
-        if not isinstance(source_label, DraggableLabel):
+        source_handle = e.source()
+        if not isinstance(source_handle, DragHandle):
             return
 
-        self._clear_highlight()
+        if self.drop_indicator.parent() == self:
+            self.layout.removeWidget(self.drop_indicator)
+            self.drop_indicator.hide()
 
-        box = self.layout()
-
-        # Remove the drop indicator
-        if self._drop_indicator.parent() == self:
-            box.removeWidget(self._drop_indicator)
-            self._drop_indicator.hide()
-
-        source_row = source_label.parent()
+        source_row = source_handle.parent()
         if not isinstance(source_row, OrderRow):
             return
 
-        # Remove row, calculate new position, re-insert
-        box.removeWidget(source_row)
-        n = self._find_insert_index(e.pos())
-        box.insertWidget(n, source_row)
+        self.layout.removeWidget(source_row)
+
+        pos = e.pos()
+        n = 0
+        while n < self.layout.count():
+            w = self.layout.itemAt(n).widget()
+            if pos.y() < w.y() + w.height() // 2:
+                break
+            n += 1
+
+        self.layout.insertWidget(n, source_row)
         e.accept()
 
         self._update_row_numbers()
         self._update_row_colors()
         self._emit_reorder()
 
-    # ------------------------------------------------------------------
-    #  Visual updates
-    # ------------------------------------------------------------------
-
-    def _clear_highlight(self):
-        """Remove highlight styling from any previously highlighted number labels"""
-        for row in self._highlighted_rows:
-            row.number_label.setStyleSheet("")
-        self._highlighted_rows.clear()
-
     def _update_row_numbers(self):
-        """Set row numbers (1-based) according to current order"""
-        num = 1
-        box = self.layout()
-        for i in range(box.count()):
-            row = box.itemAt(i).widget()
-            if isinstance(row, OrderRow):
-                row.set_number(num)
-                num += 1
+        for i in range(self.layout.count()):
+            w = self.layout.itemAt(i).widget()
+            if isinstance(w, OrderRow):
+                w.set_number(i + 1)
 
     def _update_row_colors(self):
-        """Apply alternating row background colors, with dimming for filtered rows"""
-        num = 0
-        box = self.layout()
-        for i in range(box.count()):
-            row = box.itemAt(i).widget()
-            if isinstance(row, OrderRow):
-                if row.key in self._dimmed_keys:
-                    row.setStyleSheet("background-color: palette(window);")
-                    row.drag_label.setStyleSheet("color: palette(mid);")
-                    row.number_label.setStyleSheet("color: palette(mid);")
+        for i in range(self.layout.count()):
+            w = self.layout.itemAt(i).widget()
+            if isinstance(w, OrderRow):
+                if i % 2 == 0:
+                    w.setStyleSheet("background-color: palette(alternate-base);")
                 else:
-                    if num % 2 == 0:
-                        row.setStyleSheet("background-color: palette(alternate-base);")
-                    else:
-                        row.setStyleSheet("background-color: palette(base);")
-                    row.drag_label.setStyleSheet("")
-                    row.number_label.setStyleSheet("")
-                num += 1
+                    w.setStyleSheet("background-color: palette(base);")
 
     def _emit_reorder(self):
-        """Collect current key order and invoke the callback"""
         if self._callback:
             keys = []
-            box = self.layout()
-            for i in range(box.count()):
-                row = box.itemAt(i).widget()
-                if isinstance(row, OrderRow):
-                    keys.append(row.key)
+            for i in range(self.layout.count()):
+                w = self.layout.itemAt(i).widget()
+                if isinstance(w, OrderRow):
+                    keys.append(w.key)
             self._callback(keys)
 
-    # ------------------------------------------------------------------
-    #  Public API
-    # ------------------------------------------------------------------
-
-    def get_key_order(self):
-        """Return the current list of keys in display order"""
-        keys = []
-        box = self.layout()
-        for i in range(box.count()):
-            row = box.itemAt(i).widget()
-            if isinstance(row, OrderRow):
-                keys.append(row.key)
-        return keys
-
-    def set_dimmed_keys(self, keys: set[str]):
-        """Update which keys are dimmed and refresh row colors"""
-        self._dimmed_keys = keys
-        self._update_row_colors()
+    def set_dimmed_keys(self, keys_to_dim: set):
+        """Dim de rijen waarvan de key in keys_to_dim zit."""
+        for i in range(self.layout.count()):
+            w = self.layout.itemAt(i).widget()
+            if isinstance(w, OrderRow):
+                if w.key in keys_to_dim:
+                    w.setStyleSheet("background-color: palette(window);")
+                    w.number_label.setStyleSheet("color: palette(mid);")
+                    w.text_label.setStyleSheet("color: palette(mid);")
+                else:
+                    bg = "palette(alternate-base)" if i % 2 == 0 else "palette(base)"
+                    w.setStyleSheet(f"background-color: {bg};")
+                    w.number_label.setStyleSheet("")
+                    w.text_label.setStyleSheet("")
 
     def reset_to_defaults(self, default_values: dict):
-        """Re-sort rows to match *default_values* ordering"""
-        box = self.layout()
-
-        # Collect all OrderRow widgets
-        rows = []
-        for i in range(box.count()):
-            row = box.itemAt(i).widget()
-            if isinstance(row, OrderRow):
-                rows.append(row)
-
-        # Remove from layout (without deleting)
-        for row in rows:
-            box.removeWidget(row)
-
-        # Re-insert sorted by default value
-        rows.sort(key=lambda r: default_values.get(r.key, 999))
-        for row in rows:
-            box.addWidget(row)
-
+        """Reset de volgorde naar de standaardwaarden."""
+        # Sorteer de opgeslagen items op basis van default_values
+        sorted_items = sorted(self._all_items, key=lambda item: default_values.get(item[0], 999))
+        # Verwijder alle bestaande rijen
+        for i in reversed(range(self.layout.count())):
+            w = self.layout.itemAt(i).widget()
+            if isinstance(w, OrderRow):
+                w.setParent(None)
+                w.deleteLater()
+        # Voeg opnieuw toe in de juiste volgorde
+        for key, label in sorted_items:
+            self._add_row(key, label)
         self._update_row_numbers()
         self._update_row_colors()
-        self._emit_reorder()

--- a/tinypedal/ui/font_config.py
+++ b/tinypedal/ui/font_config.py
@@ -1,0 +1,163 @@
+#  TinyPedal is an open-source overlay application for racing simulation.
+#  Copyright (C) 2022-2026 TinyPedal developers, see contributors.md file
+#
+#  This file is part of TinyPedal.
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Global font override dialog.
+"""
+
+import re
+import time
+
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import (
+    QComboBox,
+    QDialogButtonBox,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QSpinBox,
+    QVBoxLayout,
+)
+
+from .. import regex_pattern as rxp
+from ..const_file import ConfigType
+from ..setting import cfg
+from ._common import BaseDialog, UIScaler, singleton_dialog
+from .option_editors import get_font_list
+
+
+@singleton_dialog(ConfigType.CONFIG)
+class FontConfig(BaseDialog):
+    """Config global font setting"""
+
+    def __init__(self, parent, user_setting: dict, reload_func):
+        super().__init__(parent)
+        self.set_config_title("Global Font Override", cfg.filename.setting)
+
+        self.reloading = reload_func
+        self.user_setting = user_setting
+
+        # Combobox
+        self.edit_fontname = QComboBox(self)
+        self.edit_fontname.addItem("no change")
+        self.edit_fontname.addItems(get_font_list())
+        self.edit_fontname.setFixedWidth(UIScaler.size(9))
+
+        self.edit_fontsize = QSpinBox(self)
+        self.edit_fontsize.setRange(-999, 999)
+        self.edit_fontsize.setFixedWidth(UIScaler.size(9))
+
+        self.edit_fontweight = QComboBox(self)
+        self.edit_fontweight.addItem("no change")
+        self.edit_fontweight.addItems(rxp.CHOICE_COMMON[rxp.CFG_FONT_WEIGHT])
+        self.edit_fontweight.setFixedWidth(UIScaler.size(9))
+
+        self.edit_autooffset = QComboBox(self)
+        self.edit_autooffset.addItems(("no change", "enable", "disable"))
+        self.edit_autooffset.setFixedWidth(UIScaler.size(9))
+
+        self.edit_fontoffset = QSpinBox(self)
+        self.edit_fontoffset.setRange(-999, 999)
+        self.edit_fontoffset.setFixedWidth(UIScaler.size(9))
+
+        layout_option = QGridLayout()
+        layout_option.setAlignment(Qt.AlignTop)
+        layout_option.addWidget(QLabel("Font Name"), 0, 0)
+        layout_option.addWidget(self.edit_fontname, 0, 1)
+        layout_option.addWidget(QLabel("Font Size Addend"), 1, 0)
+        layout_option.addWidget(self.edit_fontsize, 1, 1)
+        layout_option.addWidget(QLabel("Font Weight"), 2, 0)
+        layout_option.addWidget(self.edit_fontweight, 2, 1)
+        layout_option.addWidget(QLabel("Enable Auto Font Offset"), 3, 0)
+        layout_option.addWidget(self.edit_autooffset, 3, 1)
+        layout_option.addWidget(QLabel("Font Offset Vertical Addend"), 4, 0)
+        layout_option.addWidget(self.edit_fontoffset, 4, 1)
+
+        # Button
+        button_apply = QDialogButtonBox(QDialogButtonBox.Apply)
+        button_apply.clicked.connect(self.applying)
+
+        button_save = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        button_save.accepted.connect(self.saving)
+        button_save.rejected.connect(self.reject)
+
+        layout_button = QHBoxLayout()
+        layout_button.addStretch(1)
+        layout_button.addWidget(button_apply)
+        layout_button.addWidget(button_save)
+
+        # Set layout
+        layout_main = QVBoxLayout()
+        layout_main.addLayout(layout_option)
+        layout_main.addLayout(layout_button)
+        layout_main.setContentsMargins(self.MARGIN, self.MARGIN, self.MARGIN, self.MARGIN)
+        self.setLayout(layout_main)
+
+    def applying(self):
+        """Save & apply"""
+        self.save_setting(self.user_setting)
+
+    def saving(self):
+        """Save & close"""
+        self.applying()
+        self.accept()  # close
+
+    def save_setting(self, dict_user: dict[str, dict]):
+        """Save setting"""
+        for setting in dict_user.values():
+            for key in setting:
+                # Font name
+                if re.search(rxp.CFG_FONT_NAME, key):
+                    font_name = self.edit_fontname.currentText()
+                    if font_name != "no change":
+                        setting[key] = font_name
+                    continue
+                # Font weight
+                if re.search(rxp.CFG_FONT_WEIGHT, key):
+                    font_weight = self.edit_fontweight.currentText()
+                    if font_weight != "no change":
+                        setting[key] = font_weight
+                    continue
+                # Font size addend
+                if re.search("font_size", key):
+                    font_size = self.edit_fontsize.value()
+                    if font_size != 0:
+                        setting[key] = max(setting[key] + font_size, 1)
+                    continue
+                # Auto font offset
+                if key == "enable_auto_font_offset":
+                    auto_offset = self.edit_autooffset.currentText()
+                    if auto_offset == "disable":
+                        setting[key] = False
+                    elif auto_offset == "enable":
+                        setting[key] = True
+                    continue
+                # Font offset vertical
+                if key == "font_offset_vertical":
+                    font_offset = self.edit_fontoffset.value()
+                    if font_offset != 0:
+                        setting[key] += font_offset
+                    continue
+        # Reset after applied
+        self.edit_fontsize.setValue(0)
+        self.edit_fontoffset.setValue(0)
+        cfg.save(0)
+        # Wait saving finish
+        while cfg.is_saving:
+            time.sleep(0.01)
+        self.reloading()

--- a/tinypedal/ui/menu.py
+++ b/tinypedal/ui/menu.py
@@ -36,7 +36,8 @@ from ..setting import cfg
 from ..update import update_checker
 from .about import About
 from .brake_editor import BrakeEditor
-from .config import FontConfig, UserConfig
+from .font_config import FontConfig
+from .config import UserConfig
 from .driver_stats_viewer import DriverStatsViewer
 from .fuel_calculator import FuelCalculator
 from .heatmap_editor import HeatmapEditor

--- a/tinypedal/ui/option_editors.py
+++ b/tinypedal/ui/option_editors.py
@@ -1,0 +1,230 @@
+#  TinyPedal is an open-source overlay application for racing simulation.
+#  Copyright (C) 2022-2026 TinyPedal developers, see contributors.md file
+#
+#  This file is part of TinyPedal.
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Editor widgets and context menu for configuration options.
+"""
+
+import os
+import re
+
+from PySide2.QtCore import QPoint, Qt
+from PySide2.QtGui import QFontDatabase
+from PySide2.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QLineEdit,
+    QMenu,
+    QWidget,
+)
+
+from .. import regex_pattern as rxp
+from ._common import (
+    DoubleClickEdit,
+    QVAL_COLOR,
+    QVAL_FLOAT,
+    QVAL_INTEGER,
+)
+
+
+# ----------------------------------------------------------------------
+# Font list helper
+# ----------------------------------------------------------------------
+def get_font_list() -> list[str]:
+    """Get all available font families list"""
+    if os.getenv("PYSIDE_OVERRIDE") == "6":  # no instance in qt6
+        return QFontDatabase.families()  # type: ignore[call-arg]
+    return QFontDatabase().families()
+
+
+# ----------------------------------------------------------------------
+# Context menu for reset
+# ----------------------------------------------------------------------
+def add_context_menu(parent: QWidget):
+    """Add context menu to parent widget for resetting to default."""
+    parent.setContextMenuPolicy(Qt.CustomContextMenu)
+    parent.customContextMenuRequested.connect(
+        lambda pos, p=parent: _context_menu_reset_option(pos, p)
+    )
+
+
+def _context_menu_reset_option(position: QPoint, parent):
+    """Show context menu with reset action."""
+    menu = QMenu()  # temporary menu, no parent
+    reset_action = menu.addAction("Reset to Default")
+    action = menu.exec_(parent.mapToGlobal(position))
+    if action == reset_action:
+        if isinstance(parent, QCheckBox):
+            parent.setChecked(parent.defaults)
+        elif isinstance(parent, QLineEdit):
+            parent.setText(str(parent.defaults))
+        elif isinstance(parent, QComboBox):
+            parent.setCurrentText(str(parent.defaults))
+
+
+# ----------------------------------------------------------------------
+# Editor factory
+# ----------------------------------------------------------------------
+def create_editor(
+    parent,
+    key: str,
+    current_val,
+    default_val,
+    update_callback,
+    *,
+    choices: list[str] | None = None,
+):
+    """
+    Create the appropriate editor widget for the given key.
+
+    Parameters
+    ----------
+    parent : QWidget
+        Parent widget.
+    key : str
+        Configuration key.
+    current_val : any
+        Current value from cache.
+    default_val : any
+        Default value from defaults.
+    update_callback : callable(key, new_value)
+        Called when the editor value changes.
+    choices : list of str, optional
+        List of choices for combo boxes (used for units/common/heatmap).
+
+    Returns
+    -------
+    QWidget
+        The editor widget.
+    """
+    # Boolean (checkbox)
+    if re.search(rxp.CFG_BOOL, key):
+        editor = QCheckBox(parent)
+        editor.setChecked(bool(current_val))
+        editor.stateChanged.connect(
+            lambda state, k=key: update_callback(k, bool(state))
+        )
+
+    # Color string (with preview)
+    elif re.search(rxp.CFG_COLOR, key):
+        editor = DoubleClickEdit(parent, mode="color", init=current_val)
+        editor.setValidator(QVAL_COLOR)
+        editor.textChanged.connect(editor.preview_color)
+        editor.setText(str(current_val))
+        editor.textChanged.connect(
+            lambda text, k=key: update_callback(k, text)
+        )
+
+    # User path string (directory)
+    elif re.search(rxp.CFG_USER_PATH, key):
+        editor = DoubleClickEdit(parent, mode="path", init=current_val)
+        editor.setText(str(current_val))
+        editor.textChanged.connect(
+            lambda text, k=key: update_callback(k, text)
+        )
+
+    # User image file path
+    elif re.search(rxp.CFG_USER_IMAGE, key):
+        editor = DoubleClickEdit(parent, mode="image", init=current_val)
+        editor.setText(str(current_val))
+        editor.textChanged.connect(
+            lambda text, k=key: update_callback(k, text)
+        )
+
+    # Font name (combo box)
+    elif re.search(rxp.CFG_FONT_NAME, key):
+        editor = QComboBox(parent)
+        editor.addItems(get_font_list())
+        editor.setCurrentText(str(current_val))
+        editor.currentTextChanged.connect(
+            lambda text, k=key: update_callback(k, text)
+        )
+
+    # Heatmap selection (combo box using provided choices)
+    elif re.search(rxp.CFG_HEATMAP, key):
+        editor = QComboBox(parent)
+        if choices:
+            editor.addItems(choices)
+        editor.setCurrentText(str(current_val))
+        editor.currentTextChanged.connect(
+            lambda text, k=key: update_callback(k, text)
+        )
+
+    # Units choice (combo box using provided choices)
+    elif any(re.search(ref, key) for ref in rxp.CHOICE_UNITS):
+        editor = QComboBox(parent)
+        if choices:
+            editor.addItems(choices)
+        else:
+            # fallback: try to get from CHOICE_UNITS based on matching ref
+            for ref, items in rxp.CHOICE_UNITS.items():
+                if re.search(ref, key):
+                    editor.addItems(items)
+                    break
+        editor.setCurrentText(str(current_val))
+        editor.currentTextChanged.connect(
+            lambda text, k=key: update_callback(k, text)
+        )
+
+    # Common choice (combo box using provided choices)
+    elif any(re.search(ref, key) for ref in rxp.CHOICE_COMMON):
+        editor = QComboBox(parent)
+        if choices:
+            editor.addItems(choices)
+        else:
+            for ref, items in rxp.CHOICE_COMMON.items():
+                if re.search(ref, key):
+                    editor.addItems(items)
+                    break
+        editor.setCurrentText(str(current_val))
+        editor.currentTextChanged.connect(
+            lambda text, k=key: update_callback(k, text)
+        )
+
+    # Clock format string (free text)
+    elif re.search(rxp.CFG_CLOCK_FORMAT, key) or re.search(rxp.CFG_STRING, key):
+        editor = QLineEdit(parent)
+        editor.setText(str(current_val))
+        editor.textChanged.connect(
+            lambda text, k=key: update_callback(k, text)
+        )
+
+    # Integer (validated line edit)
+    elif re.search(rxp.CFG_INTEGER, key):
+        editor = QLineEdit(parent)
+        editor.setValidator(QVAL_INTEGER)
+        editor.setText(str(current_val))
+        editor.textChanged.connect(
+            lambda text, k=key: update_callback(k, text)
+        )
+
+    # Float (validated line edit)
+    else:
+        # fallback to float validator
+        editor = QLineEdit(parent)
+        editor.setValidator(QVAL_FLOAT)
+        editor.setText(str(current_val))
+        editor.textChanged.connect(
+            lambda text, k=key: update_callback(k, text)
+        )
+
+    # Store default value and add context menu
+    editor.defaults = default_val
+    add_context_menu(editor)
+
+    return editor

--- a/tinypedal/ui/section_builder.py
+++ b/tinypedal/ui/section_builder.py
@@ -1,0 +1,309 @@
+#  TinyPedal is an open-source overlay application for racing simulation.
+#  Copyright (C) 2022-2026 TinyPedal developers, see contributors.md file
+#
+#  This file is part of TinyPedal.
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Build section frames for the configuration dialog.
+"""
+
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import (
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..formatter import format_option_name
+from .dragdroplist import DragDropOrderList
+from .option_editors import create_editor
+
+
+class SectionBuilder:
+    """
+    Builds all section frames for a UserConfig dialog and keeps track of created widgets.
+    """
+
+    def __init__(self, parent_dialog, current_values, update_callback, option_width,
+                 highlight_callback=None):
+        """
+        Parameters
+        ----------
+        parent_dialog : UserConfig
+            The parent configuration dialog (needed for parent widget and defaults).
+        current_values : dict
+            Dictionary of current (cached) values for all keys.
+        update_callback : callable(key, new_value)
+            Called when an editor's value changes.
+        option_width : int
+            Fixed width for editor widgets (in pixels).
+        highlight_callback : callable(column_key), optional
+            Called when a section (via its column_index_* key) is clicked.
+        """
+        self.parent = parent_dialog
+        self.current_values = current_values
+        self.update_callback = update_callback
+        self.option_width = option_width
+        self.highlight_callback = highlight_callback
+
+        # Widget references for filtering / resetting
+        self.row_widgets = {}           # key -> row container widget
+        self.row_labels = {}             # key -> QLabel widget
+        self.section_title_widgets = []  # list of (title_label, list_of_keys)
+        self.column_order_widgets = {}   # key -> DragDropOrderList
+        self.editors = {}                 # key -> editor widget (all types)
+
+        # Frames that will be built
+        self.general_frame = None
+        self.section_frames = []
+        self.column_index_frames = []
+
+    def build_section_frame(self, title, keys):
+        """
+        Build a section frame for the given keys.
+        Delegates to specialized builders based on key type.
+        """
+        if all(key.startswith("column_index_") for key in keys):
+            return self._build_column_index_frame(title, keys)
+        else:
+            return self._build_regular_section(title, keys)
+
+    def build_compact_frame(self, title, keys):
+        """
+        Build a compact two‑column frame (used for the "general" section).
+        """
+        layout = QGridLayout()
+        layout.setAlignment(Qt.AlignTop)
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        row_offset = 0
+        if title is not None:
+            header_text = (
+                format_option_name(self.parent.key_name) if title == ""
+                else format_option_name(title)
+            )
+            title_label = QLabel(f"<b>{header_text}</b>")
+            font = title_label.font()
+            font.setPointSize(font.pointSize() + 1)
+            title_label.setFont(font)
+            title_label.setStyleSheet("""
+                background-color: palette(dark);
+                color: palette(bright-text);
+                border-bottom: 2px solid palette(mid);
+                padding: 4px;
+            """)
+            layout.addWidget(title_label, 0, 0, 1, 4)
+            row_offset = 1
+            self.section_title_widgets.append((title_label, keys))
+
+        for idx, key in enumerate(keys):
+            grid_row = idx // 2 + row_offset
+            grid_col = (idx % 2) * 2  # 0 or 2
+
+            row_widget = QWidget()
+            bg = "palette(alternate-base)" if (idx // 2) % 2 == 0 else "palette(base)"
+            row_widget.setStyleSheet(f"background-color: {bg};")
+            row_widget.setProperty("_base_bg", bg)
+
+            row_layout = QHBoxLayout()
+            row_layout.setContentsMargins(4, 1, 4, 1)
+            row_layout.setSpacing(4)
+
+            label = QLabel(format_option_name(key))
+            row_layout.addWidget(label)
+
+            # Determine choices for dropdowns if needed
+            choices = self._get_choices_for_key(key)
+            editor = create_editor(
+                self.parent,
+                key,
+                self.current_values[key],
+                self.parent.default_setting[self.parent.key_name][key],
+                self.update_callback,
+                choices=choices
+            )
+            editor.setFixedHeight(22)
+            editor.setFixedWidth(self.option_width)
+            row_layout.addWidget(editor)
+
+            row_widget.setLayout(row_layout)
+            layout.addWidget(row_widget, grid_row, grid_col, 1, 2)
+
+            self.row_widgets[key] = row_widget
+            self.row_labels[key] = label
+            self.editors[key] = editor
+
+        frame = QFrame()
+        frame.setObjectName("sectionFrame")
+        frame.setLayout(layout)
+        # approximate number of rows for column balancing
+        frame.setProperty("estimated_rows", len(keys) // 2 + (1 if title is not None else 0))
+        return frame
+
+    def _build_regular_section(self, title, keys):
+        """
+        Build a standard section with title bar and alternating rows (one column).
+        """
+        layout = QGridLayout()
+        layout.setAlignment(Qt.AlignTop)
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        row_offset = 0
+        if title is not None:
+            header_text = (
+                format_option_name(self.parent.key_name) if title == ""
+                else format_option_name(title)
+            )
+            title_label = QLabel(f"<b>{header_text}</b>")
+            font = title_label.font()
+            font.setPointSize(font.pointSize() + 1)
+            title_label.setFont(font)
+            title_label.setStyleSheet("""
+                background-color: palette(dark);
+                color: palette(bright-text);
+                border-bottom: 2px solid palette(mid);
+                padding: 4px;
+            """)
+            layout.addWidget(title_label, 0, 0, 1, 2)
+            row_offset = 1
+            self.section_title_widgets.append((title_label, keys))
+
+        for idx, key in enumerate(keys):
+            row = idx + row_offset
+
+            row_widget = QWidget()
+            bg = "palette(alternate-base)" if idx % 2 == 0 else "palette(base)"
+            row_widget.setStyleSheet(f"background-color: {bg};")
+            row_widget.setProperty("_base_bg", bg)
+
+            row_layout = QHBoxLayout()
+            row_layout.setContentsMargins(4, 1, 4, 1)
+            row_layout.setSpacing(4)
+
+            label = QLabel(format_option_name(key))
+            row_layout.addWidget(label)
+
+            choices = self._get_choices_for_key(key)
+            editor = create_editor(
+                self.parent,
+                key,
+                self.current_values[key],
+                self.parent.default_setting[self.parent.key_name][key],
+                self.update_callback,
+                choices=choices
+            )
+            editor.setFixedHeight(22)
+            editor.setFixedWidth(self.option_width)
+            row_layout.addWidget(editor)
+
+            row_widget.setLayout(row_layout)
+            layout.addWidget(row_widget, row, 0, 1, 2)
+
+            self.row_widgets[key] = row_widget
+            self.row_labels[key] = label
+            self.editors[key] = editor
+
+        frame = QFrame()
+        frame.setObjectName("sectionFrame")
+        frame.setLayout(layout)
+        frame.setProperty("estimated_rows", len(keys) + (1 if title is not None else 0))
+        # Bewaar de bijbehorende keys voor later herordenen
+        frame.setProperty("section_keys", keys)
+        return frame
+
+    def _build_column_index_frame(self, title, keys):
+        """
+        Build a frame with a drag‑and‑drop list for column order settings.
+        """
+        layout = QVBoxLayout()
+        layout.setAlignment(Qt.AlignTop)
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        col_title_label = None
+        if title is not None:
+            header_text = (
+                format_option_name(self.parent.key_name) if title == ""
+                else "Sections"  # Gewijzigd: "Sections" i.p.v. "Display Order"
+            )
+            col_title_label = QLabel(f"<b>{header_text}</b>")
+            font = col_title_label.font()
+            font.setPointSize(font.pointSize() + 1)
+            col_title_label.setFont(font)
+            col_title_label.setStyleSheet("""
+                background-color: palette(dark);
+                color: palette(bright-text);
+                border-bottom: 2px solid palette(mid);
+                padding: 4px;
+            """)
+            layout.addWidget(col_title_label)
+
+        # Sort keys according to current values (they store the order index)
+        sorted_keys = sorted(
+            keys,
+            key=lambda k: self.current_values.get(k, 999)
+        )
+        items = [
+            (key, format_option_name(key[len("column_index_"):]))
+            for key in sorted_keys
+        ]
+
+        def on_reorder(new_order):
+            for index, key in enumerate(new_order, start=1):
+                self.update_callback(key, index)
+            # Laat de parent weten dat de volgorde is gewijzigd, zodat frames herschikt worden
+            if hasattr(self.parent, 'on_column_order_changed'):
+                self.parent.on_column_order_changed()
+
+        row_height = 22 + 4  # approximate editor height plus some margin
+        list_widget = DragDropOrderList(
+            items=items,
+            on_reorder_callback=on_reorder,
+            row_height=row_height,
+            parent=self.parent
+        )
+        # Verbind het signaal voor sectie‑klik als er een callback is meegegeven
+        if self.highlight_callback is not None:
+            list_widget.sectionClicked.connect(self.highlight_callback)
+
+        for key in keys:
+            self.column_order_widgets[key] = list_widget
+            # Note: we do not store a separate editor for these keys;
+            # the order is managed by the list widget.
+
+        layout.addWidget(list_widget)
+
+        if col_title_label is not None:
+            self.section_title_widgets.append((col_title_label, keys))
+
+        frame = QFrame()
+        frame.setObjectName("sectionFrame")
+        frame.setLayout(layout)
+        frame.setProperty("estimated_rows", len(keys) + (2 if title is not None else 1))
+        return frame
+
+    def _get_choices_for_key(self, key):
+        """
+        Return a list of choices for dropdowns, or None if not applicable.
+        This method can be extended to fetch dynamic lists (e.g., heatmap names).
+        """
+        # Placeholder – in the future we could query the parent for a mapping.
+        return None

--- a/tinypedal/ui/section_grouper.py
+++ b/tinypedal/ui/section_grouper.py
@@ -1,0 +1,94 @@
+#  TinyPedal is an open-source overlay application for racing simulation.
+#  Copyright (C) 2022-2026 TinyPedal developers, see contributors.md file
+#
+#  This file is part of TinyPedal.
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Group configuration keys into labelled sections by word overlap.
+"""
+
+class SectionGrouper:
+    """Groups configuration keys into labelled sections by word overlap"""
+
+    def __init__(self, min_match: int = 2):
+        self.min_match = min_match
+
+    @staticmethod
+    def _word_set(phrase: str) -> set[str]:
+        """Split underscore-delimited name into word set"""
+        return set(phrase.split("_"))
+
+    def _similar(self, topic1: str, topic2: str) -> bool:
+        """Check if two topics share enough words to belong in one section"""
+        # Direct match if one is a substring of the other
+        if topic1 in topic2 or topic2 in topic1:
+            return True
+        words1 = self._word_set(topic1)
+        words2 = self._word_set(topic2)
+        return len(words1 & words2) >= self.min_match
+
+    def group_keys(self, keys: list[str]) -> list[tuple[str | None, list[str]]]:
+        """Group keys into labelled sections, returns list of (title, key_list) tuples"""
+        # Separate column_index_* into its own group
+        fixed_groups: dict[str, list[str]] = {}
+        remaining: list[str] = []
+        for key in keys:
+            if key.startswith("column_index_"):
+                fixed_groups.setdefault("Column Index", []).append(key)
+            else:
+                remaining.append(key)
+
+        # Build sections from remaining keys
+        sections: list[tuple[str | None, list[str]]] = []
+        current_title: str | None = None
+        current_keys: list[str] = []
+        last_show: str | None = None
+
+        for key in remaining:
+            if key.startswith("show_"):
+                topic = key[5:]  # strip 'show_' prefix
+                if last_show is None:
+                    current_title = topic
+                    current_keys = [key]
+                    last_show = topic
+                elif self._similar(last_show, topic):
+                    current_keys.append(key)
+                    last_show = topic
+                else:
+                    sections.append((current_title, current_keys))
+                    current_title = topic
+                    current_keys = [key]
+                    last_show = topic
+            elif current_title is not None:
+                current_keys.append(key)
+
+        # Add last open section
+        if current_keys:
+            sections.append((current_title, current_keys))
+
+        # Collect keys that appeared before the first show_* key
+        all_assigned: set[str] = set()
+        for _, key_list in sections:
+            all_assigned.update(key_list)
+        unassigned = [k for k in remaining if k not in all_assigned]
+        if unassigned:
+            sections.insert(0, ("", unassigned))
+
+        # Append fixed groups
+        for title, fkeys in fixed_groups.items():
+            sections.append((title, fkeys))
+
+        return sections


### PR DESCRIPTION
  Refactors the `UserConfig` config dialog from a flat single-column list into a
  structured multi-column layout with labelled sections, while preserving all
  existing functionality.

  ## Changes

  ### SectionGrouper (new class)
  Groups configuration keys into labelled sections based on the order they appear
  in the JSON and word overlap between `show_*` keys:
  - Consecutive `show_*` keys that share enough common words (or one is a
    substring of the other) are merged into one section, keeping the title of
    the first key
  - Non-show keys are appended to the current section
  - `column_index_*` keys are collected into a separate fixed group
  - Keys that appear before the first `show_*` key are grouped under the widget
    name as a general section

  ### UserConfig layout
  - Replaces the flat `QGridLayout` with sectioned `QFrame` blocks, each with a
    title bar and alternating row backgrounds
  - Column count is determined dynamically on open from the available screen width
    and the widest section's natural size (up to 3 columns)
  - Columns reflow automatically via `resizeEvent` when the window is resized
    wide or narrow enough to fit a different number of columns
  - `_widest_section` is cached after initial build to avoid repeated `sizeHint`
    calls on every resize event
  - Initial window size is capped at 90% of available screen width and height
  - Uses `QApplication.primaryScreen()` for screen geometry before the window is
    shown, falls back to 1920x1080
    
     Open to feedback, suggestions, or any changes needed to better fit the project.
<img width="653" height="974" alt="Screenshot 2026-02-26 224808" src="https://github.com/user-attachments/assets/986ad225-a83f-4f16-a9f2-3ccede091525" />
<img width="1920" height="1032" alt="Screenshot 2026-02-26 224847" src="https://github.com/user-attachments/assets/a96ed9f5-7113-47b8-9424-aade91c9408c" />
