### PR TITLE
Add Display Order dialog for column index reordering

### DIFF
--- a/tinypedal/ui/__init__.py
+++ b/tinypedal/ui/__init__.py
@@ -409,4 +409,18 @@ def set_style_window(base_font_pt: int) -> str:
         About #labelAppName {{
             font-size: {font_pt_app_name}pt;
         }}
+        /* Display order dialog */
+        DisplayOrderDialog > QListView {{
+            font-size: {font_pt_item_name}pt;
+            outline: none;
+        }}
+        DisplayOrderDialog > QListView::item {{
+            border: none;
+            min-height: 1.25em;
+            padding: 0.25em 0.25em 0.25em 0;
+        }}
+        DisplayOrderDialog > QListView::item:selected {{
+            selection-color: {color_active_highlighted_text};
+            background: {color_active_highlight};
+        }}
     """)

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -243,8 +243,9 @@ class UserConfig(BaseDialog):
         button_reset = QDialogButtonBox(QDialogButtonBox.Reset)
         button_reset.clicked.connect(self.reset_setting)
 
-        self.button_display_order = QPushButton("Display Order")
-        self.button_display_order.clicked.connect(self.on_display_order_clicked)
+        if cfg_type == ConfigType.WIDGET:
+            button_display_order = QPushButton("Display Order")
+            button_display_order.clicked.connect(self.open_display_order)
 
         button_apply = QDialogButtonBox(QDialogButtonBox.Apply)
         button_apply.clicked.connect(self.applying)
@@ -288,7 +289,8 @@ class UserConfig(BaseDialog):
         layout_main.addLayout(layout_search)
         layout_main.addWidget(scroll_box)
         layout_button.addWidget(button_reset)
-        layout_button.addWidget(self.button_display_order)
+        if cfg_type == ConfigType.WIDGET:
+            layout_button.addWidget(button_display_order)
         layout_button.addStretch(1)
         layout_button.addWidget(button_apply)
         layout_button.addWidget(button_save)
@@ -315,6 +317,20 @@ class UserConfig(BaseDialog):
     def saving(self):
         """Save & close"""
         self.save_setting(is_apply=False)
+
+    def open_display_order(self):
+        """Open display order dialog"""
+        options = self.user_setting[self.key_name]
+        column_keys = [k for k in options if k.startswith("column_index_")]
+        default_values = {k: self.default_setting[self.key_name][k] for k in column_keys}
+        dialog = DisplayOrderDialog(self, options=options, default_values=default_values)
+        dialog.open()
+
+    def update_column_index(self):
+        """Update column index editor"""
+        options = self.user_setting[self.key_name]
+        for key, editor in self.option_column.items():
+            editor.setText(str(options[key]))
 
     def reset_setting(self):
         """Reset setting"""
@@ -634,30 +650,6 @@ class UserConfig(BaseDialog):
         # Add layout
         layout.addWidget(editor, idx, COLUMN_OPTION)
         self.option_float[key] = editor
-
-    #Display order functions
-    def update_column_index(self):
-        """Update displayed index values from the user setting dictionary."""
-        options_dict = self.user_setting[self.key_name]
-        for key, line_edit in self.option_column.items():
-            line_edit.setText(str(options_dict[key]))
-
-    def on_display_order_clicked(self):
-        # Get options and generate column keys
-        options = self.user_setting[self.key_name]
-        column_keys = [k for k in options.keys() if k.startswith("column_index_")]
-
-        # Get default values
-        default_values = {k: self.default_setting[self.key_name][k] for k in column_keys}
-
-        # Create and open dialog (non-blocking)
-        dialog = DisplayOrderDialog(
-            self,
-            options=options,
-            default_values=default_values,
-            update_callback=self.update_column_index
-        )
-        dialog.open()
 
 
 def set_preset_name(cfg_type: str):

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -217,7 +217,6 @@ class UserConfig(BaseDialog):
         super().__init__(parent)
         self.set_config_title(format_option_name(key_name), set_preset_name(cfg_type))
 
-        self.setWindowFlags(self.windowFlags() | Qt.Window)
         self.reloading = reload_func
         self.key_name = key_name
         self.cfg_type = cfg_type

--- a/tinypedal/ui/config.py
+++ b/tinypedal/ui/config.py
@@ -44,6 +44,7 @@ from PySide2.QtWidgets import (
     QSpinBox,
     QVBoxLayout,
     QWidget,
+    QPushButton,
 )
 
 from .. import regex_pattern as rxp
@@ -62,6 +63,7 @@ from ._common import (
     UIScaler,
     singleton_dialog,
 )
+from .display_order import DisplayOrderDialog
 
 COLUMN_LABEL = 0  # grid layout column index
 COLUMN_OPTION = 1
@@ -215,6 +217,7 @@ class UserConfig(BaseDialog):
         super().__init__(parent)
         self.set_config_title(format_option_name(key_name), set_preset_name(cfg_type))
 
+        self.setWindowFlags(self.windowFlags() | Qt.Window)
         self.reloading = reload_func
         self.key_name = key_name
         self.cfg_type = cfg_type
@@ -233,9 +236,15 @@ class UserConfig(BaseDialog):
         self.option_integer: dict = {}
         self.option_float: dict = {}
 
+        # key = "column_index_*", value = QLineEdit
+        self.option_column: dict = {}
+
         # Button
         button_reset = QDialogButtonBox(QDialogButtonBox.Reset)
         button_reset.clicked.connect(self.reset_setting)
+
+        self.button_display_order = QPushButton("Display Order")
+        self.button_display_order.clicked.connect(self.on_display_order_clicked)
 
         button_apply = QDialogButtonBox(QDialogButtonBox.Apply)
         button_apply.clicked.connect(self.applying)
@@ -279,6 +288,7 @@ class UserConfig(BaseDialog):
         layout_main.addLayout(layout_search)
         layout_main.addWidget(scroll_box)
         layout_button.addWidget(button_reset)
+        layout_button.addWidget(self.button_display_order)
         layout_button.addStretch(1)
         layout_button.addWidget(button_apply)
         layout_button.addWidget(button_save)
@@ -475,7 +485,9 @@ class UserConfig(BaseDialog):
                 continue
             # Int
             if re.search(rxp.CFG_INTEGER, key):
-                self.__add_option_integer(idx, key, layout)
+                editor = self.__add_option_integer(idx, key, layout)
+                if key.startswith("column_index_"):
+                    self.option_column[key] = editor
                 continue
             # Float or int
             self.__add_option_float(idx, key, layout)
@@ -607,6 +619,7 @@ class UserConfig(BaseDialog):
         # Add layout
         layout.addWidget(editor, idx, COLUMN_OPTION)
         self.option_integer[key] = editor
+        return editor
 
     def __add_option_float(self, idx, key, layout):
         """Float"""
@@ -621,6 +634,30 @@ class UserConfig(BaseDialog):
         # Add layout
         layout.addWidget(editor, idx, COLUMN_OPTION)
         self.option_float[key] = editor
+
+    #Display order functions
+    def update_column_index(self):
+        """Update displayed index values from the user setting dictionary."""
+        options_dict = self.user_setting[self.key_name]
+        for key, line_edit in self.option_column.items():
+            line_edit.setText(str(options_dict[key]))
+
+    def on_display_order_clicked(self):
+        # Get options and generate column keys
+        options = self.user_setting[self.key_name]
+        column_keys = [k for k in options.keys() if k.startswith("column_index_")]
+
+        # Get default values
+        default_values = {k: self.default_setting[self.key_name][k] for k in column_keys}
+
+        # Create and open dialog (non-blocking)
+        dialog = DisplayOrderDialog(
+            self,
+            options=options,
+            default_values=default_values,
+            update_callback=self.update_column_index
+        )
+        dialog.open()
 
 
 def set_preset_name(cfg_type: str):

--- a/tinypedal/ui/display_order.py
+++ b/tinypedal/ui/display_order.py
@@ -30,6 +30,7 @@ from PySide2.QtWidgets import (
     QPushButton,
     QSizePolicy,
     QVBoxLayout,
+    QAbstractItemView
 )
 
 from ..formatter import format_option_name
@@ -51,46 +52,28 @@ class DisplayOrderDialog(BaseDialog):
         # List
         self.list_widget = QListWidget()
         self.list_widget.setSelectionMode(QListWidget.SingleSelection)
+        self.list_widget.setDragDropMode(QAbstractItemView.InternalMove)
+        self.list_widget.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
         self._populate_list(self.options)
-
-        self.list_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        row_height = self.list_widget.sizeHintForRow(0)
-        total_height = row_height * self.list_widget.count() + 2 * self.list_widget.frameWidth()
-        self.list_widget.setFixedHeight(total_height)
-
-        # Up/Down button
-        self.up_btn = QPushButton("▲")
-        self.up_btn.setFixedWidth(UIScaler.size(4))
-        self.up_btn.clicked.connect(self._move_up)
-
-        self.down_btn = QPushButton("▼")
-        self.down_btn.setFixedWidth(UIScaler.size(4))
-        self.down_btn.clicked.connect(self._move_down)
-
-        button_layout = QVBoxLayout()
-        button_layout.addWidget(self.up_btn)
-        button_layout.addWidget(self.down_btn)
-        button_layout.addStretch()
 
         top_layout = QHBoxLayout()
         top_layout.addWidget(self.list_widget)
-        top_layout.addLayout(button_layout)
 
         # Button
-        self.reset_btn = QPushButton("Reset")
-        self.reset_btn.clicked.connect(self._reset_order)
+        reset_btn = QPushButton("Reset")
+        reset_btn.clicked.connect(self._reset_order)
 
-        self.apply_btn = QPushButton("Apply")
-        self.apply_btn.clicked.connect(self.update_order)
+        apply_btn = QPushButton("Apply")
+        apply_btn.clicked.connect(self.update_order)
 
-        self.close_btn = QPushButton("Close")
-        self.close_btn.clicked.connect(self.reject)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.reject)
 
         bottom_layout = QHBoxLayout()
-        bottom_layout.addWidget(self.reset_btn)
+        bottom_layout.addWidget(reset_btn)
         bottom_layout.addStretch()
-        bottom_layout.addWidget(self.apply_btn)
-        bottom_layout.addWidget(self.close_btn)
+        bottom_layout.addWidget(apply_btn)
+        bottom_layout.addWidget(close_btn)
 
         # Layout
         main_layout = QVBoxLayout()
@@ -99,8 +82,8 @@ class DisplayOrderDialog(BaseDialog):
         main_layout.setContentsMargins(self.MARGIN, self.MARGIN, self.MARGIN, self.MARGIN)
         self.setLayout(main_layout)
 
-        self.adjustSize()
-        self.setFixedSize(self.size())
+        # Calculate size based on content after populating
+        self._fit_to_content()
 
     def update_order(self):
         """Update display order"""
@@ -123,7 +106,9 @@ class DisplayOrderDialog(BaseDialog):
         """Populate list"""
         self.list_widget.clear()
         for key in sorted(self.column_keys, key=lambda k: values[k]):
-            item = QListWidgetItem(format_option_name(key))
+            # Strip prefix, then format
+            short_key = key.replace("column_index_", "")
+            item = QListWidgetItem(format_option_name(short_key))
             item.setData(Qt.UserRole, key)
             self.list_widget.addItem(item)
 
@@ -132,18 +117,32 @@ class DisplayOrderDialog(BaseDialog):
         self._populate_list(self.default_values)
         self.list_widget.setCurrentRow(0)
 
-    def _move_up(self):
-        """Move selected item up"""
-        row = self.list_widget.currentRow()
-        if row > 0:
-            item = self.list_widget.takeItem(row)
-            self.list_widget.insertItem(row - 1, item)
-            self.list_widget.setCurrentRow(row - 1)
 
-    def _move_down(self):
-        """Move selected item down"""
-        row = self.list_widget.currentRow()
-        if row < self.list_widget.count() - 1:
-            item = self.list_widget.takeItem(row)
-            self.list_widget.insertItem(row + 1, item)
-            self.list_widget.setCurrentRow(row + 1)
+    def _fit_to_content(self):
+        """Fit dialog size to content"""
+        self.layout().activate()
+
+        # Get width needed for longest item
+        width = 0
+        for row in range(self.list_widget.count()):
+            item = self.list_widget.item(row)
+            item_width = self.list_widget.fontMetrics().horizontalAdvance(item.text())
+            width = max(width, item_width)
+
+        # Add scrollbar width if needed, plus margins
+        scrollbar_width = self.style().pixelMetric(self.style().PM_ScrollBarExtent)
+        margins = self.layout().contentsMargins()
+
+        total_width = (width + scrollbar_width + margins.left() + margins.right() +
+                    UIScaler.size(6))
+
+        # Height based on item count (with max limit)
+        item_height = self.list_widget.sizeHintForRow(0)
+        max_visible_items = 15  # Limit height for long lists
+        visible_items = min(self.list_widget.count(), max_visible_items)
+
+        total_height = (item_height * visible_items + margins.top() + margins.bottom() +
+                        UIScaler.size(10))  # button row
+
+        self.resize(total_width, total_height)
+        self.setMinimumSize(total_width, total_height)

--- a/tinypedal/ui/display_order.py
+++ b/tinypedal/ui/display_order.py
@@ -18,14 +18,9 @@
 
 """
 Display order dialog
-
-Small popup dialog for reordering column_index_* settings.
-Opened from WidgetConfig via "Display Order" button.
-Sized to fit all items — no scrollbar needed.
 """
 
 from __future__ import annotations
-from typing import Callable
 
 from PySide2.QtCore import Qt
 from PySide2.QtWidgets import (
@@ -40,44 +35,30 @@ from PySide2.QtWidgets import (
 from ..formatter import format_option_name
 from ._common import BaseDialog, UIScaler
 
+
 class DisplayOrderDialog(BaseDialog):
-    """Popup dialog to reorder column_index_* settings.
+    """Display order dialog"""
 
-    Uses QListWidget with up/down buttons.
-    Window sized to show all items without scrollbar.
-    """
-
-    def __init__(self, parent, options: dict, default_values: dict, update_callback: Callable):
-        """
-        Args:
-            parent: WidgetConfig instance.
-            options: the user_setting[self.key_name] dict containing column_index_* keys.
-            default_values: dict of default values for column_index_* keys.
-            update_callback: function to call when Apply is clicked.
-        """
+    def __init__(self, parent, options: dict, default_values: dict):
         super().__init__(parent)
         self.setWindowTitle("Display Order")
 
         self._parent = parent
         self.options = options
         self.default_values = default_values
-        self.update_callback = update_callback
+        self.column_keys = [k for k in options if k.startswith("column_index_")]
 
-        # Generate column_keys from options dict
-        self.column_keys = [k for k in options.keys() if k.startswith("column_index_")]
-
-        # ---------- List widget ----------
+        # List
         self.list_widget = QListWidget()
         self.list_widget.setSelectionMode(QListWidget.SingleSelection)
-        self._populate_list()
+        self._populate_list(self.options)
 
-        # Fix height to avoid scrollbar
         self.list_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         row_height = self.list_widget.sizeHintForRow(0)
         total_height = row_height * self.list_widget.count() + 2 * self.list_widget.frameWidth()
         self.list_widget.setFixedHeight(total_height)
 
-        # ---------- Up/Down buttons ----------
+        # Up/Down button
         self.up_btn = QPushButton("▲")
         self.up_btn.setFixedWidth(UIScaler.size(4))
         self.up_btn.clicked.connect(self._move_up)
@@ -91,20 +72,19 @@ class DisplayOrderDialog(BaseDialog):
         button_layout.addWidget(self.down_btn)
         button_layout.addStretch()
 
-        # ---------- Top area (list + buttons) ----------
         top_layout = QHBoxLayout()
         top_layout.addWidget(self.list_widget)
         top_layout.addLayout(button_layout)
 
-        # ---------- Bottom buttons ----------
+        # Button
         self.reset_btn = QPushButton("Reset")
         self.reset_btn.clicked.connect(self._reset_order)
 
         self.apply_btn = QPushButton("Apply")
-        self.apply_btn.clicked.connect(self._on_apply)  # Don't close dialog
+        self.apply_btn.clicked.connect(self.update_order)
 
         self.close_btn = QPushButton("Close")
-        self.close_btn.clicked.connect(self.reject)  # Close dialog
+        self.close_btn.clicked.connect(self.reject)
 
         bottom_layout = QHBoxLayout()
         bottom_layout.addWidget(self.reset_btn)
@@ -112,57 +92,48 @@ class DisplayOrderDialog(BaseDialog):
         bottom_layout.addWidget(self.apply_btn)
         bottom_layout.addWidget(self.close_btn)
 
-        # ---------- Main layout ----------
+        # Layout
         main_layout = QVBoxLayout()
         main_layout.addLayout(top_layout)
         main_layout.addLayout(bottom_layout)
         main_layout.setContentsMargins(self.MARGIN, self.MARGIN, self.MARGIN, self.MARGIN)
         self.setLayout(main_layout)
 
-        # Size dialog to fit content exactly (no resizing)
         self.adjustSize()
         self.setFixedSize(self.size())
 
-
-
-    def _on_apply(self):
-        """Apply changes but keep dialog open."""
+    def update_order(self):
+        """Update display order"""
         new_order = self.get_order()
-        # Update in-memory options
         for key, index in new_order.items():
             self.options[key] = index
-        # Trigger parent update via callback
-        self.update_callback()
+        self._parent.update_column_index()
+        self._parent.applying()
 
-    # ------------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------------
-    def _populate_list(self):
-        """Fill list with keys sorted by current index."""
-        # Build current_values from self.options
-        current_values = {k: self.options[k] for k in self.column_keys}
+    def get_order(self) -> dict:
+        """Get display order"""
+        order = {}
+        for row in range(self.list_widget.count()):
+            item = self.list_widget.item(row)
+            key = item.data(Qt.UserRole)
+            order[key] = row + 1
+        return order
 
-        sorted_keys = sorted(self.column_keys, key=lambda k: current_values[k])
-        for key in sorted_keys:
-            display_name = format_option_name(key)
-            item = QListWidgetItem(display_name)
+    def _populate_list(self, values: dict):
+        """Populate list"""
+        self.list_widget.clear()
+        for key in sorted(self.column_keys, key=lambda k: values[k]):
+            item = QListWidgetItem(format_option_name(key))
             item.setData(Qt.UserRole, key)
             self.list_widget.addItem(item)
 
-    def _on_apply(self):
-        """Apply changes but keep dialog open."""
-        new_order = self.get_order()
-        # Update in-memory options
-        for key, index in new_order.items():
-            self.options[key] = index
-        # Trigger parent update via callback
-        self.update_callback()
+    def _reset_order(self):
+        """Reset display order"""
+        self._populate_list(self.default_values)
+        self.list_widget.setCurrentRow(0)
 
-    # ------------------------------------------------------------------------
-    # Slot methods
-    # ------------------------------------------------------------------------
     def _move_up(self):
-        """Move selected item one position up."""
+        """Move selected item up"""
         row = self.list_widget.currentRow()
         if row > 0:
             item = self.list_widget.takeItem(row)
@@ -170,32 +141,9 @@ class DisplayOrderDialog(BaseDialog):
             self.list_widget.setCurrentRow(row - 1)
 
     def _move_down(self):
-        """Move selected item one position down."""
+        """Move selected item down"""
         row = self.list_widget.currentRow()
         if row < self.list_widget.count() - 1:
             item = self.list_widget.takeItem(row)
             self.list_widget.insertItem(row + 1, item)
             self.list_widget.setCurrentRow(row + 1)
-
-    def _reset_order(self):
-        """Restore default order (based on default_values)."""
-        self.list_widget.clear()
-        sorted_keys = sorted(self.column_keys, key=lambda k: self.default_values[k])
-        for key in sorted_keys:
-            display_name = format_option_name(key)
-            item = QListWidgetItem(display_name)
-            item.setData(Qt.UserRole, key)
-            self.list_widget.addItem(item)
-        self.list_widget.setCurrentRow(0)
-
-    # ------------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------------
-    def get_order(self) -> dict:
-        """Return dictionary mapping each key to its new 1‑based index."""
-        order = {}
-        for row in range(self.list_widget.count()):
-            item = self.list_widget.item(row)
-            key = item.data(Qt.UserRole)
-            order[key] = row + 1   # 1‑based index
-        return order

--- a/tinypedal/ui/display_order.py
+++ b/tinypedal/ui/display_order.py
@@ -53,7 +53,7 @@ class DisplayOrderDialog(BaseDialog):
         self.list_widget = QListWidget()
         self.list_widget.setSelectionMode(QListWidget.SingleSelection)
         self.list_widget.setDragDropMode(QAbstractItemView.InternalMove)
-        self.list_widget.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
+        self.list_widget.setMinimumHeight(UIScaler.size(10))
         self._populate_list(self.options)
 
         top_layout = QHBoxLayout()
@@ -83,7 +83,7 @@ class DisplayOrderDialog(BaseDialog):
         self.setLayout(main_layout)
 
         # Calculate size based on content after populating
-        self._fit_to_content()
+        # self._fit_to_content()
 
     def update_order(self):
         """Update display order"""
@@ -118,31 +118,31 @@ class DisplayOrderDialog(BaseDialog):
         self.list_widget.setCurrentRow(0)
 
 
-    def _fit_to_content(self):
-        """Fit dialog size to content"""
-        self.layout().activate()
+    # def _fit_to_content(self):
+    #     """Fit dialog size to content"""
+    #     self.layout().activate()
 
-        # Get width needed for longest item
-        width = 0
-        for row in range(self.list_widget.count()):
-            item = self.list_widget.item(row)
-            item_width = self.list_widget.fontMetrics().horizontalAdvance(item.text())
-            width = max(width, item_width)
+    #     # Get width needed for longest item
+    #     width = 0
+    #     for row in range(self.list_widget.count()):
+    #         item = self.list_widget.item(row)
+    #         item_width = self.list_widget.fontMetrics().horizontalAdvance(item.text())
+    #         width = max(width, item_width)
 
-        # Add scrollbar width if needed, plus margins
-        scrollbar_width = self.style().pixelMetric(self.style().PM_ScrollBarExtent)
-        margins = self.layout().contentsMargins()
+    #     # Add scrollbar width if needed, plus margins
+    #     scrollbar_width = self.style().pixelMetric(self.style().PM_ScrollBarExtent)
+    #     margins = self.layout().contentsMargins()
 
-        total_width = (width + scrollbar_width + margins.left() + margins.right() +
-                    UIScaler.size(6))
+    #     total_width = (width + scrollbar_width + margins.left() + margins.right() +
+    #                 UIScaler.size(6))
 
-        # Height based on item count (with max limit)
-        item_height = self.list_widget.sizeHintForRow(0)
-        max_visible_items = 15  # Limit height for long lists
-        visible_items = min(self.list_widget.count(), max_visible_items)
+    #     # Height based on item count (with max limit)
+    #     item_height = self.list_widget.sizeHintForRow(0)
+    #     max_visible_items = 15  # Limit height for long lists
+    #     visible_items = min(self.list_widget.count(), max_visible_items)
 
-        total_height = (item_height * visible_items + margins.top() + margins.bottom() +
-                        UIScaler.size(10))  # button row
+    #     total_height = (item_height * visible_items + margins.top() + margins.bottom() +
+    #                     UIScaler.size(10))  # button row
 
-        self.resize(total_width, total_height)
-        self.setMinimumSize(total_width, total_height)
+    #     self.resize(total_width, total_height)
+    #     self.setMinimumSize(total_width, total_height)

--- a/tinypedal/ui/display_order.py
+++ b/tinypedal/ui/display_order.py
@@ -1,0 +1,201 @@
+#  TinyPedal is an open-source overlay application for racing simulation.
+#  Copyright (C) 2022-2026 TinyPedal developers, see contributors.md file
+#
+#  This file is part of TinyPedal.
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Display order dialog
+
+Small popup dialog for reordering column_index_* settings.
+Opened from WidgetConfig via "Display Order" button.
+Sized to fit all items — no scrollbar needed.
+"""
+
+from __future__ import annotations
+from typing import Callable
+
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import (
+    QHBoxLayout,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+)
+
+from ..formatter import format_option_name
+from ._common import BaseDialog, UIScaler
+
+class DisplayOrderDialog(BaseDialog):
+    """Popup dialog to reorder column_index_* settings.
+
+    Uses QListWidget with up/down buttons.
+    Window sized to show all items without scrollbar.
+    """
+
+    def __init__(self, parent, options: dict, default_values: dict, update_callback: Callable):
+        """
+        Args:
+            parent: WidgetConfig instance.
+            options: the user_setting[self.key_name] dict containing column_index_* keys.
+            default_values: dict of default values for column_index_* keys.
+            update_callback: function to call when Apply is clicked.
+        """
+        super().__init__(parent)
+        self.setWindowTitle("Display Order")
+
+        self._parent = parent
+        self.options = options
+        self.default_values = default_values
+        self.update_callback = update_callback
+
+        # Generate column_keys from options dict
+        self.column_keys = [k for k in options.keys() if k.startswith("column_index_")]
+
+        # ---------- List widget ----------
+        self.list_widget = QListWidget()
+        self.list_widget.setSelectionMode(QListWidget.SingleSelection)
+        self._populate_list()
+
+        # Fix height to avoid scrollbar
+        self.list_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        row_height = self.list_widget.sizeHintForRow(0)
+        total_height = row_height * self.list_widget.count() + 2 * self.list_widget.frameWidth()
+        self.list_widget.setFixedHeight(total_height)
+
+        # ---------- Up/Down buttons ----------
+        self.up_btn = QPushButton("▲")
+        self.up_btn.setFixedWidth(UIScaler.size(4))
+        self.up_btn.clicked.connect(self._move_up)
+
+        self.down_btn = QPushButton("▼")
+        self.down_btn.setFixedWidth(UIScaler.size(4))
+        self.down_btn.clicked.connect(self._move_down)
+
+        button_layout = QVBoxLayout()
+        button_layout.addWidget(self.up_btn)
+        button_layout.addWidget(self.down_btn)
+        button_layout.addStretch()
+
+        # ---------- Top area (list + buttons) ----------
+        top_layout = QHBoxLayout()
+        top_layout.addWidget(self.list_widget)
+        top_layout.addLayout(button_layout)
+
+        # ---------- Bottom buttons ----------
+        self.reset_btn = QPushButton("Reset")
+        self.reset_btn.clicked.connect(self._reset_order)
+
+        self.apply_btn = QPushButton("Apply")
+        self.apply_btn.clicked.connect(self._on_apply)  # Don't close dialog
+
+        self.close_btn = QPushButton("Close")
+        self.close_btn.clicked.connect(self.reject)  # Close dialog
+
+        bottom_layout = QHBoxLayout()
+        bottom_layout.addWidget(self.reset_btn)
+        bottom_layout.addStretch()
+        bottom_layout.addWidget(self.apply_btn)
+        bottom_layout.addWidget(self.close_btn)
+
+        # ---------- Main layout ----------
+        main_layout = QVBoxLayout()
+        main_layout.addLayout(top_layout)
+        main_layout.addLayout(bottom_layout)
+        main_layout.setContentsMargins(self.MARGIN, self.MARGIN, self.MARGIN, self.MARGIN)
+        self.setLayout(main_layout)
+
+        # Size dialog to fit content exactly (no resizing)
+        self.adjustSize()
+        self.setFixedSize(self.size())
+
+
+
+    def _on_apply(self):
+        """Apply changes but keep dialog open."""
+        new_order = self.get_order()
+        # Update in-memory options
+        for key, index in new_order.items():
+            self.options[key] = index
+        # Trigger parent update via callback
+        self.update_callback()
+
+    # ------------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------------
+    def _populate_list(self):
+        """Fill list with keys sorted by current index."""
+        # Build current_values from self.options
+        current_values = {k: self.options[k] for k in self.column_keys}
+
+        sorted_keys = sorted(self.column_keys, key=lambda k: current_values[k])
+        for key in sorted_keys:
+            display_name = format_option_name(key)
+            item = QListWidgetItem(display_name)
+            item.setData(Qt.UserRole, key)
+            self.list_widget.addItem(item)
+
+    def _on_apply(self):
+        """Apply changes but keep dialog open."""
+        new_order = self.get_order()
+        # Update in-memory options
+        for key, index in new_order.items():
+            self.options[key] = index
+        # Trigger parent update via callback
+        self.update_callback()
+
+    # ------------------------------------------------------------------------
+    # Slot methods
+    # ------------------------------------------------------------------------
+    def _move_up(self):
+        """Move selected item one position up."""
+        row = self.list_widget.currentRow()
+        if row > 0:
+            item = self.list_widget.takeItem(row)
+            self.list_widget.insertItem(row - 1, item)
+            self.list_widget.setCurrentRow(row - 1)
+
+    def _move_down(self):
+        """Move selected item one position down."""
+        row = self.list_widget.currentRow()
+        if row < self.list_widget.count() - 1:
+            item = self.list_widget.takeItem(row)
+            self.list_widget.insertItem(row + 1, item)
+            self.list_widget.setCurrentRow(row + 1)
+
+    def _reset_order(self):
+        """Restore default order (based on default_values)."""
+        self.list_widget.clear()
+        sorted_keys = sorted(self.column_keys, key=lambda k: self.default_values[k])
+        for key in sorted_keys:
+            display_name = format_option_name(key)
+            item = QListWidgetItem(display_name)
+            item.setData(Qt.UserRole, key)
+            self.list_widget.addItem(item)
+        self.list_widget.setCurrentRow(0)
+
+    # ------------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------------
+    def get_order(self) -> dict:
+        """Return dictionary mapping each key to its new 1‑based index."""
+        order = {}
+        for row in range(self.list_widget.count()):
+            item = self.list_widget.item(row)
+            key = item.data(Qt.UserRole)
+            order[key] = row + 1   # 1‑based index
+        return order


### PR DESCRIPTION
Summary

Add a DisplayOrderDialog for reordering column_index_* settings via up/down buttons, accessible from the widget config dialog's "Display Order" button.

    Reorder column_index_* values using a sorted list with up/down buttons
    Apply button saves changes to disk and reloads the widget immediately
    Reset button restores default column order
    Dialog is sized to fit all items without scrollbar
    Display Order button only appears for widget config type

Changes

    tinypedal/ui/display_order.py — new DisplayOrderDialog class
    tinypedal/ui/config.py — open_display_order and update_column_index methods, Display Order button wired up
